### PR TITLE
make CI fail if clippy finds something

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Format
       run: cargo fmt --message-format human -- --check
     - name: Clippy
-      run: cargo clippy
+      run: cargo clippy -- -Dwarnings
     - name: Document
       run: cargo doc
     - name: Test


### PR DESCRIPTION
Run `clippy` with `-Dwarnings` so that the process exits non-zero if it finds a lint, which will cause GitHub to fail the build.