### PR TITLE
Install additional Rust toolchain components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy, rustfmt
     - uses: actions/checkout@v5
     - name: Build
       run: cargo build


### PR DESCRIPTION
I got a CI error when merging to main because rustfmt was not installed. This PR explicitly requests installing clippy and rustfmt. This issue might have been caused by the tools pre-installed on a worker getting out of sync with the latest stable toolchain version.