### PR TITLE
rename crate to `zk-cred-longfellow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zk-cred-rs"
+name = "zk-cred-longfellow"
 version = "0.1.0"
 dependencies = [
  "aes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "zk-cred-rs"
+name = "zk-cred-longfellow"
 version = "0.1.0"
 edition = "2024"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# `zk-cred-rs`
+# `zk-cred-longfellow`
 
-A Rust implementation of the [Anonymous Credentials from ECDSA][anon-creds-ecdsa] scheme, following
-the [draft `libZK` specification][draft-google-cfrg-libzk].
+A Rust implementation of the [Anonymous Credentials from ECDSA][anon-creds-ecdsa] scheme, also known
+as Longfellow, following the [draft `libZK` specification][draft-google-cfrg-libzk].
 
 This project is part of [ISRG](https://abetterinternet.org)'s research into
 [digital identity][isrg-digital-identity].


### PR DESCRIPTION
Having "-rs" in the project name is gauche, and the Google team seems to be converging on "longfellow" as the name for the proof system and protocol, not just their implementation.