### PR TITLE
Add square method to FieldElement

### DIFF
--- a/src/fields/fieldp128/mod.rs
+++ b/src/fields/fieldp128/mod.rs
@@ -15,8 +15,8 @@ use crate::{
         fieldp128::ops::{
             fiat_p128_add, fiat_p128_from_bytes, fiat_p128_from_montgomery,
             fiat_p128_montgomery_domain_field_element, fiat_p128_mul,
-            fiat_p128_non_montgomery_domain_field_element, fiat_p128_opp, fiat_p128_sub,
-            fiat_p128_to_bytes, fiat_p128_to_montgomery,
+            fiat_p128_non_montgomery_domain_field_element, fiat_p128_opp, fiat_p128_square,
+            fiat_p128_sub, fiat_p128_to_bytes, fiat_p128_to_montgomery,
         },
     },
 };
@@ -82,6 +82,12 @@ impl FieldElement for FieldP128 {
 
     fn from_u128(value: u128) -> Self {
         Self::from_u128_const(value)
+    }
+
+    fn square(&self) -> Self {
+        let mut out = fiat_p128_montgomery_domain_field_element([0; 2]);
+        fiat_p128_square(&mut out, &self.0);
+        Self(out)
     }
 }
 

--- a/src/fields/fieldp256/mod.rs
+++ b/src/fields/fieldp256/mod.rs
@@ -15,8 +15,8 @@ use crate::{
         fieldp256::ops::{
             fiat_p256_add, fiat_p256_from_bytes, fiat_p256_from_montgomery,
             fiat_p256_montgomery_domain_field_element, fiat_p256_mul,
-            fiat_p256_non_montgomery_domain_field_element, fiat_p256_opp, fiat_p256_sub,
-            fiat_p256_to_bytes, fiat_p256_to_montgomery,
+            fiat_p256_non_montgomery_domain_field_element, fiat_p256_opp, fiat_p256_square,
+            fiat_p256_sub, fiat_p256_to_bytes, fiat_p256_to_montgomery,
         },
     },
 };
@@ -77,6 +77,12 @@ impl FieldElement for FieldP256 {
 
     fn from_u128(value: u128) -> Self {
         Self::from_u128_const(value)
+    }
+
+    fn square(&self) -> Self {
+        let mut out = fiat_p256_montgomery_domain_field_element([0; 4]);
+        fiat_p256_square(&mut out, &self.0);
+        Self(out)
     }
 }
 

--- a/src/fields/fieldp256_2.rs
+++ b/src/fields/fieldp256_2.rs
@@ -23,6 +23,10 @@ impl FieldElement for FieldP256_2 {
     fn from_u128(value: u128) -> Self {
         Self(QuadraticExtension::<FieldP256>::from_u128(value))
     }
+
+    fn square(&self) -> Self {
+        Self(QuadraticExtension::square(&self.0))
+    }
 }
 
 impl Debug for FieldP256_2 {

--- a/src/fields/fieldp521/mod.rs
+++ b/src/fields/fieldp521/mod.rs
@@ -13,9 +13,9 @@ use crate::{
     fields::{
         CodecFieldElement, FieldElement,
         fieldp521::ops::{
-            fiat_p521_carry_add, fiat_p521_carry_mul, fiat_p521_carry_opp, fiat_p521_carry_sub,
-            fiat_p521_from_bytes, fiat_p521_loose_field_element, fiat_p521_relax,
-            fiat_p521_tight_field_element, fiat_p521_to_bytes,
+            fiat_p521_carry_add, fiat_p521_carry_mul, fiat_p521_carry_opp, fiat_p521_carry_square,
+            fiat_p521_carry_sub, fiat_p521_from_bytes, fiat_p521_loose_field_element,
+            fiat_p521_relax, fiat_p521_tight_field_element, fiat_p521_to_bytes,
         },
     },
 };
@@ -68,6 +68,14 @@ impl FieldElement for FieldP521 {
 
     fn from_u128(value: u128) -> Self {
         Self::from_u128_const(value)
+    }
+
+    fn square(&self) -> Self {
+        let mut loose = fiat_p521_loose_field_element([0; 9]);
+        fiat_p521_relax(&mut loose, &self.0);
+        let mut out = fiat_p521_tight_field_element([0; 9]);
+        fiat_p521_carry_square(&mut out, &loose);
+        Self(out)
     }
 }
 

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -51,6 +51,9 @@ pub trait FieldElement:
     fn is_zero(&self) -> Choice {
         self.ct_eq(&Self::ZERO)
     }
+
+    /// Square a field element.
+    fn square(&self) -> Self;
 }
 
 /// An element of a finite field with a defined serialization format.
@@ -405,6 +408,15 @@ mod tests {
         let mut temp = three;
         temp -= F::ONE;
         assert_eq!(temp, F::TWO);
+
+        for x in [F::ZERO, F::ONE, three, nine, neg_one] {
+            assert_eq!(x.square(), x * x);
+        }
+        let mut value = F::from(u64::MAX);
+        for _ in 0..20 {
+            assert_eq!(value.square(), value * value);
+            value *= value;
+        }
     }
 
     fn field_element_test_codec<F: CodecFieldElement>() {


### PR DESCRIPTION
This adds a `FieldElement::square()` method, because this can typically be implemented more efficiently than general multiplication.