### PR TITLE
Run WASM tests in a browser as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,9 @@ jobs:
     - uses: actions/checkout@v5
     - name: Build
       run: wasm-pack build
-    - name: Test
+    - name: Test (Node.js)
       run: wasm-pack test --node
+    - name: Test (Firefox)
+      run: wasm-pack test --firefox --headless
+      env:
+        WASM_BINDGEN_USE_BROWSER: "1"


### PR DESCRIPTION
This adds another step to CI to run WASM tests in a headless browser.