### PR TITLE
Generate linear and quadratic constraints from padded sumcheck proof

### DIFF
--- a/src/fields/field2_128/mod.rs
+++ b/src/fields/field2_128/mod.rs
@@ -17,7 +17,7 @@ use subtle::ConstantTimeEq;
 
 use crate::{
     Codec,
-    fields::{CodecFieldElement, FieldElement},
+    fields::{CodecFieldElement, FieldElement, LagrangePolynomialFieldElement},
 };
 
 /// An element of the field GF(2^128).
@@ -42,6 +42,38 @@ impl FieldElement for Field2_128 {
 
 impl CodecFieldElement for Field2_128 {
     const NUM_BITS: u32 = 128;
+}
+
+impl LagrangePolynomialFieldElement for Field2_128 {
+    fn sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF2 = GF(2)
+        // x = polygen(GF2)
+        // GF2_128.<x> = GF2.extension(x^128 + x^7 + x^2 + x + 1)
+        // GF2_128(x).inverse().to_integer()
+        Self::from_u128(170141183460469231731687303715884105795)
+    }
+
+    fn one_minus_sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF2 = GF(2)
+        // x = polygen(GF2)
+        // GF2_128.<x> = GF2.extension(x^128 + x^7 + x^2 + x + 1)
+        // GF2_128(1 - x).inverse().to_integer()
+        Self::from_u128(340282366920938463463374607431768211330)
+    }
+
+    fn sumcheck_p2_squared_minus_sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF2 = GF(2)
+        // x = polygen(GF2)
+        // GF2_128.<x> = GF2.extension(x^128 + x^7 + x^2 + x + 1)
+        // GF2_128(x^2 - x).inverse().to_integer()
+        Self::from_u128(170141183460469231731687303715884105665)
+    }
 }
 
 impl Debug for Field2_128 {

--- a/src/fields/fieldp128/mod.rs
+++ b/src/fields/fieldp128/mod.rs
@@ -11,7 +11,7 @@ use subtle::ConstantTimeEq;
 use crate::{
     Codec,
     fields::{
-        CodecFieldElement, FieldElement,
+        CodecFieldElement, FieldElement, LagrangePolynomialFieldElement,
         fieldp128::ops::{
             fiat_p128_add, fiat_p128_from_bytes, fiat_p128_from_montgomery,
             fiat_p128_montgomery_domain_field_element, fiat_p128_mul,
@@ -93,6 +93,35 @@ impl FieldElement for FieldP128 {
 
 impl CodecFieldElement for FieldP128 {
     const NUM_BITS: u32 = 128;
+}
+
+impl LagrangePolynomialFieldElement for FieldP128 {
+    fn sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF(2^128-2^108+1)(2).inverse().to_bytes(byteorder='little')
+        //
+        // Unwrap safety: this constant is a valid field element.
+        Self::try_from(b"\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf8\xff\x7f").unwrap()
+    }
+
+    fn one_minus_sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF(2^128-2^108+1)(1 - 2).inverse().to_bytes(byteorder='little')
+        //
+        // Unwrap safety: this constant is a valid field element.
+        Self::try_from(b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\xff\xff").unwrap()
+    }
+
+    fn sumcheck_p2_squared_minus_sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF(2^128-2^108+1)(2^2 - 2).inverse().to_bytes(byteorder='little')
+        //
+        // Unwrap safety: this constant is a valid field element.
+        Self::try_from(b"\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf8\xff\x7f").unwrap()
+    }
 }
 
 impl Debug for FieldP128 {

--- a/src/fields/fieldp256/mod.rs
+++ b/src/fields/fieldp256/mod.rs
@@ -11,7 +11,7 @@ use subtle::ConstantTimeEq;
 use crate::{
     Codec,
     fields::{
-        CodecFieldElement, FieldElement,
+        CodecFieldElement, FieldElement, LagrangePolynomialFieldElement,
         fieldp256::ops::{
             fiat_p256_add, fiat_p256_from_bytes, fiat_p256_from_montgomery,
             fiat_p256_montgomery_domain_field_element, fiat_p256_mul,
@@ -88,6 +88,50 @@ impl FieldElement for FieldP256 {
 
 impl CodecFieldElement for FieldP256 {
     const NUM_BITS: u32 = 256;
+}
+
+impl LagrangePolynomialFieldElement for FieldP256 {
+    fn sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF(0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff)(2) \
+        //   .inverse().to_bytes(byteorder='little')
+        //
+        // Unwrap safety: this constant is a valid field element.
+        Self::try_from(
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+            \x00\x00\x80\x00\x00\x00\x80\xff\xff\xff\x7f",
+        )
+        .unwrap()
+    }
+
+    fn one_minus_sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF(0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff)(1 - 2) \
+        //   .inverse().to_bytes(byteorder='little')
+        //
+        // Unwrap safety: this constant is a valid field element.
+        Self::try_from(
+            b"\xfe\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+            \x00\x00\x00\x01\x00\x00\x00\xff\xff\xff\xff",
+        )
+        .unwrap()
+    }
+
+    fn sumcheck_p2_squared_minus_sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF(0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff)(2^2 - 2) \
+        //   .inverse().to_bytes(byteorder='little')
+        //
+        // Unwrap safety: this constant is a valid field element.
+        Self::try_from(
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+            \x00\x00\x80\x00\x00\x00\x80\xff\xff\xff\x7f",
+        )
+        .unwrap()
+    }
 }
 
 impl Debug for FieldP256 {

--- a/src/fields/fieldp521/mod.rs
+++ b/src/fields/fieldp521/mod.rs
@@ -11,7 +11,7 @@ use subtle::ConstantTimeEq;
 use crate::{
     Codec,
     fields::{
-        CodecFieldElement, FieldElement,
+        CodecFieldElement, FieldElement, LagrangePolynomialFieldElement,
         fieldp521::ops::{
             fiat_p521_carry_add, fiat_p521_carry_mul, fiat_p521_carry_opp, fiat_p521_carry_square,
             fiat_p521_carry_sub, fiat_p521_from_bytes, fiat_p521_loose_field_element,
@@ -81,6 +81,53 @@ impl FieldElement for FieldP521 {
 
 impl CodecFieldElement for FieldP521 {
     const NUM_BITS: u32 = 521;
+}
+
+impl LagrangePolynomialFieldElement for FieldP521 {
+    fn sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF(2^521 - 1)(2).inverse().to_bytes(byteorder='little')
+        //
+        // Unwrap safety: this constant is a valid field element.
+        Self::try_from(
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+            \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+            \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+            \x00\x00\x01",
+        )
+        .unwrap()
+    }
+
+    fn one_minus_sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF(2^521 - 1)(1 - 2).inverse().to_bytes(byteorder='little')
+        //
+        // Unwrap safety: this constant is a valid field element.
+        Self::try_from(
+            b"\xfe\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+            \xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+            \xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+            \xff\xff\x01",
+        )
+        .unwrap()
+    }
+
+    fn sumcheck_p2_squared_minus_sumcheck_p2_mul_inv() -> Self {
+        // Computed in SageMath:
+        //
+        // GF(2^521 - 1)(2^2 - 2).inverse().to_bytes(byteorder='little')
+        //
+        // Unwrap safety: this constant is a valid field element.
+        Self::try_from(
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+            \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+            \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+            \x00\x00\x01",
+        )
+        .unwrap()
+    }
 }
 
 impl Debug for FieldP521 {

--- a/src/sumcheck/constraints.rs
+++ b/src/sumcheck/constraints.rs
@@ -1,0 +1,459 @@
+//! Generation of constraints from a padded sumcheck proof, used by Ligero prover and verifier.
+//! As specified in [draft-google-cfrg-libzk-01 section 6.6][1]
+//!
+//! [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-6.6
+
+use crate::{
+    circuit::Circuit,
+    fields::{CodecFieldElement, LagrangePolynomialFieldElement},
+    sumcheck::{
+        Proof,
+        bind::{ElementwiseSum, SumcheckArray, bindeq},
+        symbolic::{SymbolicExpression, Term},
+        witness::WitnessLayout,
+    },
+    transcript::Transcript,
+};
+use serde::Deserialize;
+
+/// A term of a linear constraint consisting of a triple (c, j, k), per [4.4.2][1]. This is one
+/// element of the constraint matrix A for verifying that A * W = b. Several of these terms sum
+/// together into one of the elements of `ProofConstraints::linear_constraint_rhs`.
+///
+/// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-4.4.2
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinearConstraintLhsTerm<FieldElement> {
+    /// The constraint number or row of A. This is an index into the vector `b`, which we represent
+    /// as `ProofConstraints::linear_constraint_rhs`. This is `c` in the specification.
+    pub constraint_number: usize,
+    /// The index into the witness vector W. This is `j` in the specification.
+    pub witness_index: usize,
+    /// The constant factor `k`.
+    pub constant_factor: FieldElement,
+}
+
+/// A quadratic constraint consisting of a triple (x, y, z), per [4.4.2][1]. For an array of
+/// witnesses W, this constrains `W[x] * W[y] = W[z]`.
+///
+/// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-4.4.2
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub struct QuadraticConstraint {
+    pub x: usize,
+    pub y: usize,
+    pub z: usize,
+}
+
+/// Ligero constraints generated from a Sumcheck proof.
+pub struct ProofConstraints<FieldElement> {
+    /// Terms contributing to the left hand sides of linear constraints.
+    linear_constraint_lhs: Vec<LinearConstraintLhsTerm<FieldElement>>,
+
+    /// Vector of right hand sides of linear constraints.
+    linear_constraint_rhs: Vec<FieldElement>,
+
+    /// Quadratic constraints: one per circuit layer.
+    quadratic_constraints: Vec<QuadraticConstraint>,
+}
+
+impl<FE: CodecFieldElement + LagrangePolynomialFieldElement> ProofConstraints<FE> {
+    /// Construct constraints from the provided proof of execution for the circuit and public
+    /// inputs.
+    ///
+    /// Corresponds to `constraints_circuit` in [1]. That definition takes arguments `sym_pad` and
+    /// `sym_private_inputs`, but since the whole point is that we don't know what those values are,
+    /// it doesn't make sense to represent them as arguments.
+    ///
+    /// `ligero_commitment` is the commitment computed per [4.3][2], which is needed to initialize
+    /// the transcript.
+    ///
+    /// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-6.6
+    /// [2]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-4.3
+    pub fn from_proof(
+        circuit: &Circuit,
+        public_inputs: &[FE],
+        transcript: &mut Transcript,
+        ligero_commitment: &[u8],
+        proof: &Proof<FE>,
+    ) -> Result<Self, anyhow::Error> {
+        let mut constraints = Self {
+            linear_constraint_lhs: Vec::with_capacity(
+                // On each layer, 3 terms for vl, vr, vl * vr
+                3 * circuit.num_layers()
+                // On each layer past the first, 2 terms for the previous layer's vl, vr
+                + 2 * (circuit.num_layers() - 1)
+                    + circuit.logw_sum()
+                        * 2 // witness elements per polynomial
+                        * 2 // hands per round/logw
+                    + circuit.num_private_inputs()
+                    + 2, // sym_layer_pad.vl and sym_layer_pad.vr
+            ),
+            linear_constraint_rhs: Vec::with_capacity(1 + circuit.num_layers()),
+            quadratic_constraints: Vec::with_capacity(circuit.num_layers()),
+        };
+
+        let witness_layout = WitnessLayout::from_circuit(circuit);
+
+        transcript.initialize(Some(ligero_commitment), circuit, public_inputs)?;
+
+        // Choose the bindings for the output layer.
+        let output_wire_bindings = transcript.generate_output_wire_bindings::<FE>(circuit)?;
+        let mut bindings = [output_wire_bindings.clone(), output_wire_bindings];
+
+        // Claims for left and right hand variables. Initially, these correspond to the output layer
+        // of the circuit, and thus are zeroes and don't have any symbolic part. As we iterate over
+        // the circuit layers, the claims will be updated and will include symbolic parts.
+        let mut claims = [FE::ZERO; 2];
+
+        for (layer_index, (circuit_layer, proof_layer)) in
+            circuit.layers.iter().zip(proof.layers.iter()).enumerate()
+        {
+            // Choose alpha and beta for this layer
+            let alpha = transcript.generate_challenge(1)?[0];
+            let beta = transcript.generate_challenge(1)?[0];
+
+            // The combined quad, aka QZ[g, l, r], a three dimensional array.
+            let combined_quad = circuit.combined_quad(layer_index, beta)?;
+
+            // Bind the combined quad to G.
+            let mut bound_quad = combined_quad
+                .bind(&bindings[0])
+                .elementwise_sum(&combined_quad.bind(&bindings[1]).scale(alpha));
+
+            // Reduce bound_quad to a Vec<Vec<FE>> so that we can later bind to the correct
+            // dimension.
+            let mut bound_quad = bound_quad.remove(0);
+
+            // Allocate room for the new bindings this layer will generate
+            let mut new_bindings = [
+                vec![FE::ZERO; circuit_layer.logw()],
+                vec![FE::ZERO; circuit_layer.logw()],
+            ];
+
+            // For each layer, we output a linear constraint:
+            //
+            //  LET known_part + symbolic_part = sym_claim
+            //  symbolic_part
+            //  - (Q * layer_proof.vr) * sym_layer_pad.vl
+            //  - (Q * layer_proof.vl) * sym_layer_pad.vr
+            //  - Q * sym_layer_pad.vl_vr
+            // =
+            //  Q * layer_proof.vl * layer_proof.vr - known_part
+            //
+            // The LHS of this constraint will consist of two SymbolicTerms for the previous layer's
+            // vl and vr (to compute this layer's claims), plus two terms (p0 and p2) for each
+            // polynomial in the layer, plus three more terms for this layer's vl, vr, vl*vr.
+            //
+            // The RHS can be computed straightforwardly and so we get one element per layer.
+            //
+            // Q is the quad once reduced down to a single value, which is bound_quad[0][0] for us.
+
+            let mut layer_claim = SymbolicExpression::new(layer_index);
+
+            let mut claim_0 = Term::from_known(claims[0]);
+            let mut claim_1 = Term::from_known(claims[1]) * alpha;
+
+            if layer_index > 0 {
+                // For layers past the first, claims is computed from the previous layer's vl and
+                // vr, so we need linear constraint terms for that symbolic manipulation.
+                let (vl_witness, vr_witness, _) =
+                    witness_layout.wire_witness_indices(layer_index - 1);
+
+                claim_0.with_witness(vl_witness);
+                claim_1.with_witness(vr_witness);
+            }
+
+            layer_claim += claim_0;
+            layer_claim += claim_1;
+
+            for (round, polynomial_pair) in proof_layer.polynomials.iter().enumerate() {
+                for (hand, polynomial) in polynomial_pair.iter().enumerate() {
+                    transcript.write_polynomial(polynomial)?;
+
+                    let challenge = transcript.generate_challenge(1)?;
+                    new_bindings[hand][round] = challenge[0];
+
+                    let (p0_witness, p2_witness) =
+                        witness_layout.polynomial_witness_indices(layer_index, round, hand);
+
+                    // The proof contains padded polynomial points p0_hat and p2_hat where
+                    // p0 = p0_hat - p0_pad and p2 = p2_hat - p2_pad. p1 is interpolated and so its
+                    // padded polynomial does not appear in the proof, but we still have constraint
+                    // terms for its symbolic manipulation.
+                    //
+                    // Compute the current claim:
+                    //
+                    //   claim = p0 * lag_0(challenge)
+                    //     + p1 * lag_1(challenge)
+                    //     + p2 * lag_2(challenge)
+                    //
+                    // Expanding p1 = prev_claim - p0 and rearranging:
+                    //
+                    //   claim = prev_claim * lag_1(challenge)
+                    //     + p0 * (lag_0(challenge) - lag_1(challenge))
+                    //     + p2 * lag_2(challenge)
+
+                    // lag_1(challenge) * prev_claim
+                    layer_claim *= FE::lagrange_basis_polynomial_1(challenge[0]);
+
+                    // p0 * (lag_0(challenge) - lag_1(challenge)):
+                    layer_claim += (Term::new(p0_witness) + polynomial.p0)
+                        * (FE::lagrange_basis_polynomial_0(challenge[0])
+                            - FE::lagrange_basis_polynomial_1(challenge[0]));
+
+                    // p2 * lag_2(challenge):
+                    layer_claim += (Term::new(p2_witness) + polynomial.p2)
+                        * FE::lagrange_basis_polynomial_2(challenge[0]);
+
+                    bound_quad = bound_quad.bind(&challenge).transpose();
+                }
+            }
+
+            // Specification interpretation verification: over the course of the loop above, we bind
+            // bound_quad to single field elements enough times that it should be reduced to a
+            // single non-zero element.
+            for (i, row) in bound_quad.iter().enumerate() {
+                for (j, element) in row.iter().enumerate() {
+                    if i != 0 && j != 0 {
+                        assert_eq!(*element, FE::ZERO, "bound quad: {bound_quad:?}");
+                    }
+                }
+            }
+
+            let (vl_witness, vr_witness, vl_vr_witness) =
+                witness_layout.wire_witness_indices(layer_index);
+
+            // Output the three remaining terms of the linear constraint for this layer.
+            // - (Q * layer_proof.vr) * sym_layer_pad.vl
+            layer_claim += Term::new(vl_witness) * -bound_quad[0][0] * proof_layer.vr;
+            // - (Q * layer_proof.vl) * sym_layer_pad.vr
+            layer_claim += Term::new(vr_witness) * -bound_quad[0][0] * proof_layer.vl;
+            // - Q * sym_layer_pad.vl_vr
+            layer_claim += Term::new(vl_vr_witness) * -bound_quad[0][0];
+
+            // Output the LHS terms of the layer linear constraint
+            constraints
+                .linear_constraint_lhs
+                .extend(layer_claim.lhs_terms());
+
+            // Output linear constraint RHS Q * layer_proof.vl * layer_proof.vr - known
+            constraints
+                .linear_constraint_rhs
+                .push(bound_quad[0][0] * proof_layer.vl * proof_layer.vr - layer_claim.known());
+
+            // Output quadratic constraint sym_layer_pad.vl * sym_layer_pad.vr = sym_layer_pad.vl_vr
+            constraints.quadratic_constraints.push(QuadraticConstraint {
+                x: vl_witness,
+                y: vr_witness,
+                z: vl_vr_witness,
+            });
+
+            // Commit to the padded evaluations of l and r. The specification implies they are
+            // written as individual field elements, but longfellow-zk writes them as an array.
+            transcript.write_field_element_array(&[proof_layer.vl, proof_layer.vr])?;
+
+            // Update claims and bindings for the next layer.
+            claims = [proof_layer.vl, proof_layer.vr];
+            bindings = new_bindings;
+        }
+
+        // Output the linear constraint that the final claims match the binding of the inputs:
+        //
+        //      SUM_{i} (eq2[i + npub] * sym_private_inputs[i])
+        //      - sym_layer_pad.vl
+        //      - gamma * sym_layer_pad.vr
+        //    =
+        //      - SUM_{i} (eq2[i] * public_inputs[i])
+        //      + claims[0]
+        //      + gamma * claims[1]
+        //
+        // where sym_layer_pad is the padding on the input layer
+        let gamma = transcript.generate_challenge(1)?[0];
+        let eq2 = bindeq(&bindings[0]).elementwise_sum(&bindeq(&bindings[1]).scale(gamma));
+        let input_layer_index = circuit.num_layers();
+
+        let mut final_claim = SymbolicExpression::new(input_layer_index);
+
+        // One linear constraint term for each private input
+        for (private_input_index, private_input_witness) in
+            witness_layout.private_input_witness_indices().enumerate()
+        {
+            final_claim += Term::new(private_input_witness)
+                * eq2[private_input_index + circuit.num_public_inputs()];
+        }
+
+        let (vl_witness, vr_witness, _) =
+            witness_layout.wire_witness_indices(input_layer_index - 1);
+
+        // Linear constraint term for sym_layer_pad.vl
+        final_claim += Term::new(vl_witness) * -FE::ONE;
+
+        // Linear constraint term for sym_layer_pad.vr
+        final_claim += Term::new(vr_witness) * -gamma;
+
+        // Linear constraint RHS
+        let rhs = claims[0] + gamma * claims[1]
+            - public_inputs
+                .iter()
+                .zip(eq2.iter())
+                .fold(FE::ZERO, |sum, (public_input_i, eq2_i)| {
+                    sum + *public_input_i * eq2_i
+                });
+
+        constraints
+            .linear_constraint_lhs
+            .extend(final_claim.lhs_terms());
+        constraints.linear_constraint_rhs.push(rhs);
+
+        Ok(constraints)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        circuit::{Evaluation, tests::CircuitTestVector},
+        fields::{FieldElement, fieldp128::FieldP128},
+        sumcheck::Prover,
+    };
+
+    #[test]
+    fn self_consistent() {
+        let (test_vector, circuit) =
+            CircuitTestVector::decode("longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b");
+
+        let witness_layout = WitnessLayout::from_circuit(&circuit);
+
+        let evaluation: Evaluation<FieldP128> = circuit
+            .evaluate(&test_vector.valid_inputs.unwrap())
+            .unwrap();
+
+        let mut proof_transcript = Transcript::new(b"test").unwrap();
+
+        // Fork the transcript
+        let mut constraint_transcript = proof_transcript.clone();
+
+        let proof = Prover::new(&circuit, FieldP128::sample)
+            .prove(&evaluation, &mut proof_transcript, Some(b"fake commitment"))
+            .unwrap();
+
+        // Ensure our witness vector length is consistent with witness layout, and with the
+        // witnesses described in test vector constraints.
+        assert_eq!(witness_layout.length(), proof.witness.len());
+
+        let constraints = ProofConstraints::from_proof(
+            &circuit,
+            evaluation.public_inputs(circuit.num_public_inputs()),
+            &mut constraint_transcript,
+            b"fake commitment",
+            &proof.proof,
+        )
+        .unwrap();
+
+        // Transcripts should have received the same sequence of writes.
+        assert_eq!(proof_transcript, constraint_transcript);
+
+        // Check that we allocated appropriate size for LHS terms. Ideally we won't reallocate in
+        // the constraint generator loop.
+        assert_eq!(
+            constraints.linear_constraint_lhs.len(),
+            3 * circuit.num_layers()
+                + 2 * (circuit.num_layers() - 1)
+                + circuit.logw_sum() * 2 * 2
+                + circuit.num_private_inputs()
+                + 2
+        );
+
+        for lhs_term in &constraints.linear_constraint_lhs {
+            // All LHS terms should refer to elements of the RHS and witness vectors.
+            assert!(lhs_term.constraint_number < constraints.linear_constraint_rhs.len());
+            assert!(lhs_term.witness_index < witness_layout.length());
+            // No LHS element should have a constant factor of 0.
+            assert_ne!(lhs_term.constant_factor, FieldP128::ZERO);
+        }
+
+        let mut lhs_summed = vec![FieldP128::ZERO; constraints.linear_constraint_rhs.len()];
+        for LinearConstraintLhsTerm {
+            constraint_number,
+            witness_index,
+            constant_factor,
+        } in constraints.linear_constraint_lhs
+        {
+            lhs_summed[constraint_number] += proof.witness[witness_index] * constant_factor;
+        }
+
+        assert_eq!(lhs_summed, constraints.linear_constraint_rhs);
+
+        assert_eq!(
+            constraints.linear_constraint_rhs.len(),
+            circuit.num_layers() + 1
+        );
+
+        assert_eq!(
+            constraints.quadratic_constraints.len(),
+            circuit.num_layers()
+        );
+
+        for QuadraticConstraint { x, y, z } in constraints.quadratic_constraints {
+            assert_eq!(proof.witness[x] * proof.witness[y], proof.witness[z]);
+        }
+    }
+
+    #[test]
+    fn longfellow_rfc_1_87474f308020535e57a778a82394a14106f8be5b() {
+        let (test_vector, circuit) =
+            CircuitTestVector::decode("longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b");
+
+        let test_vector_constraints = test_vector.constraints.unwrap();
+        let test_vector_ligero_commitment =
+            hex::decode(test_vector.ligero_commitment.as_ref().unwrap()).unwrap();
+
+        let evaluation: Evaluation<FieldP128> = circuit
+            .evaluate(&test_vector.valid_inputs.unwrap())
+            .unwrap();
+
+        let mut proof_transcript = Transcript::new(b"test").unwrap();
+
+        // Fork the transcript
+        let mut constraint_transcript = proof_transcript.clone();
+
+        let proof = Prover::new(&circuit, || {
+            FieldP128::from_u128(test_vector.pad.unwrap().into())
+        })
+        .prove(
+            &evaluation,
+            &mut proof_transcript,
+            Some(&test_vector_ligero_commitment),
+        )
+        .unwrap();
+
+        let constraints = ProofConstraints::from_proof(
+            &circuit,
+            evaluation.public_inputs(circuit.num_public_inputs()),
+            &mut constraint_transcript,
+            &test_vector_ligero_commitment,
+            &proof.proof,
+        )
+        .unwrap();
+
+        let test_vector_rhs_terms = test_vector_constraints.linear_constraint_rhs();
+
+        assert_eq!(constraints.linear_constraint_rhs, test_vector_rhs_terms);
+
+        let mut lhs_summed = vec![FieldP128::ZERO; constraints.linear_constraint_rhs.len()];
+        for LinearConstraintLhsTerm {
+            constraint_number,
+            witness_index,
+            constant_factor,
+        } in constraints.linear_constraint_lhs
+        {
+            lhs_summed[constraint_number] += proof.witness[witness_index] * constant_factor;
+        }
+        assert_eq!(lhs_summed, test_vector_constraints.linear_constraint_rhs());
+
+        assert_eq!(
+            constraints.quadratic_constraints,
+            test_vector_constraints.quadratic
+        );
+    }
+}

--- a/src/sumcheck/symbolic.rs
+++ b/src/sumcheck/symbolic.rs
@@ -1,0 +1,244 @@
+use crate::{fields::FieldElement, sumcheck::constraints::LinearConstraintLhsTerm};
+use std::ops::{Add, AddAssign, Mul, MulAssign};
+
+/// A symbolic expression, used to accumulate symbolic terms that contribute to a circuit layer's
+/// linear constraint.
+#[derive(Debug, Clone)]
+pub struct SymbolicExpression<FieldElement> {
+    known: FieldElement,
+    constraint_number: usize,
+    terms: Vec<Symbolic<FieldElement>>,
+}
+
+impl<FE: FieldElement> SymbolicExpression<FE> {
+    /// A new, empty symbolic expression contributing to a linear constraint for the specified
+    /// circuit layer.
+    pub fn new(layer_index: usize) -> Self {
+        Self {
+            known: FE::ZERO,
+            constraint_number: layer_index,
+            terms: Vec::new(),
+        }
+    }
+
+    /// The known portion of this expression. Its contribution to the linear constraint's right hand
+    /// side.
+    pub fn known(&self) -> FE {
+        self.known
+    }
+
+    /// The linear constraint LHS terms for this expression.
+    pub fn lhs_terms(&self) -> Vec<LinearConstraintLhsTerm<FE>> {
+        self.terms
+            .iter()
+            // Terms with no witness index do not contribute to LHS
+            .filter_map(|term| {
+                term.witness_index
+                    .map(|witness_index| LinearConstraintLhsTerm {
+                        constraint_number: self.constraint_number,
+                        witness_index,
+                        constant_factor: term.constant_factor,
+                    })
+            })
+            .collect()
+    }
+}
+
+impl<FE: FieldElement> AddAssign<Term<FE>> for SymbolicExpression<FE> {
+    fn add_assign(&mut self, rhs: Term<FE>) {
+        self.known += rhs.known;
+        self.terms.push(rhs.symbolic);
+    }
+}
+
+impl<FE: FieldElement> MulAssign<FE> for SymbolicExpression<FE> {
+    fn mul_assign(&mut self, rhs: FE) {
+        self.known *= rhs;
+        self.terms.iter_mut().for_each(|term| *term *= rhs);
+    }
+}
+
+/// The symbolic portion of a [`Term`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Symbolic<FieldElement> {
+    /// The index into the witness vector W. This is `j` in the specification.
+    witness_index: Option<usize>,
+    /// The constant factor `k`.
+    constant_factor: FieldElement,
+}
+
+impl<FE: FieldElement> MulAssign<FE> for Symbolic<FE> {
+    fn mul_assign(&mut self, rhs: FE) {
+        self.constant_factor *= rhs;
+    }
+}
+
+/// A symbolic term in a symbolic expression, consisting of `known` if `symbolic.witness_index` is
+/// `None`, or `known + symbolic.constant_factor * W[symbolic.witness_index]`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Term<FieldElement> {
+    /// The known portion of the expression.
+    known: FieldElement,
+    /// The symbolic portion of the expression.
+    symbolic: Symbolic<FieldElement>,
+}
+
+impl<FE: FieldElement> Term<FE> {
+    pub fn new(witness_index: usize) -> Self {
+        Self {
+            known: FE::ZERO,
+            symbolic: Symbolic {
+                witness_index: Some(witness_index),
+                constant_factor: FE::ONE,
+            },
+        }
+    }
+
+    pub fn from_known(known: FE) -> Self {
+        Self {
+            known,
+            symbolic: Symbolic {
+                witness_index: None,
+                constant_factor: FE::ONE,
+            },
+        }
+    }
+
+    pub fn with_witness(&mut self, index: usize) {
+        self.symbolic.witness_index = Some(index);
+    }
+}
+
+impl<FE: FieldElement> Add<FE> for Term<FE> {
+    type Output = Self;
+
+    fn add(self, rhs: FE) -> Self::Output {
+        Self {
+            known: self.known + rhs,
+            ..self
+        }
+    }
+}
+
+impl<FE: FieldElement> Mul<FE> for Term<FE> {
+    type Output = Self;
+
+    fn mul(self, rhs: FE) -> Self::Output {
+        Self {
+            symbolic: Symbolic {
+                constant_factor: self.symbolic.constant_factor * rhs,
+                ..self.symbolic
+            },
+            known: self.known * rhs,
+        }
+    }
+}
+
+impl<FE: FieldElement> MulAssign<FE> for Term<FE> {
+    fn mul_assign(&mut self, rhs: FE) {
+        self.known *= rhs;
+        self.symbolic *= rhs;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fields::fieldp256::FieldP256;
+
+    #[test]
+    fn term_ops() {
+        let term = Term::new(1);
+
+        let term = term + FieldP256::from_u128(2);
+
+        assert_eq!(
+            term,
+            Term {
+                known: FieldP256::from_u128(2),
+                symbolic: Symbolic {
+                    witness_index: Some(1),
+                    constant_factor: FieldP256::ONE,
+                }
+            }
+        );
+
+        let mut term = term * FieldP256::from_u128(5);
+
+        assert_eq!(
+            term,
+            Term {
+                known: FieldP256::from_u128(10),
+                symbolic: Symbolic {
+                    witness_index: Some(1),
+                    constant_factor: FieldP256::from_u128(5),
+                }
+            }
+        );
+
+        term *= FieldP256::from_u128(6);
+
+        assert_eq!(
+            term,
+            Term {
+                known: FieldP256::from_u128(60),
+                symbolic: Symbolic {
+                    witness_index: Some(1),
+                    constant_factor: FieldP256::from_u128(30),
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn expression_ops() {
+        let mut expression = SymbolicExpression::new(11);
+        assert_eq!(expression.lhs_terms(), vec![]);
+        assert_eq!(expression.known(), FieldP256::ZERO);
+
+        // Term with both known and symbolic part
+        expression += Term::new(22) + FieldP256::from_u128(11);
+
+        // Term with only symbolic part
+        expression += Term::new(33);
+
+        // Term with only known part
+        expression += Term::from_known(FieldP256::from_u128(3));
+
+        assert_eq!(
+            expression.lhs_terms(),
+            vec![
+                LinearConstraintLhsTerm {
+                    constraint_number: 11,
+                    witness_index: 22,
+                    constant_factor: FieldP256::ONE,
+                },
+                LinearConstraintLhsTerm {
+                    constraint_number: 11,
+                    witness_index: 33,
+                    constant_factor: FieldP256::ONE,
+                },
+            ]
+        );
+        assert_eq!(expression.known(), FieldP256::from_u128(14));
+
+        expression *= FieldP256::from_u128(6);
+
+        assert_eq!(
+            expression.lhs_terms(),
+            vec![
+                LinearConstraintLhsTerm {
+                    constraint_number: 11,
+                    witness_index: 22,
+                    constant_factor: FieldP256::from_u128(6),
+                },
+                LinearConstraintLhsTerm {
+                    constraint_number: 11,
+                    witness_index: 33,
+                    constant_factor: FieldP256::from_u128(6),
+                },
+            ]
+        );
+        assert_eq!(expression.known(), FieldP256::from_u128(14 * 6));
+    }
+}

--- a/src/sumcheck/witness.rs
+++ b/src/sumcheck/witness.rs
@@ -1,0 +1,147 @@
+//! Implements the witness vector, referred to as W in the specification.
+
+use crate::circuit::{Circuit, CircuitLayer};
+use std::ops::Range;
+
+/// The witness vector W. This is a 1D vector containing values known to the prover but not the
+/// verifier:
+///
+///   - private inputs to the circuit (count depends on the circuit)
+///   - one-time-pad for polynomials at each layer (2 * 2 * logw elements per circuit layer)
+///   - one-time-pad for vl, vr and vl * vr for each layer of the circuit (three elements per
+///     circuit layer)
+///
+/// The prover and verifier both manipulate these quantities symbolically, so this structure doesn't
+/// actually contain witness values. Rather, it is used to determine where in the witness vector a
+/// given value occurs so that the right challenge value can be looked up later.
+pub(crate) struct WitnessLayout {
+    /// The number of private inputs to the circuit.
+    num_private_inputs: usize,
+    /// The number of polynomial evaluations on each layer.
+    logw: Vec<usize>,
+}
+
+impl WitnessLayout {
+    pub(crate) fn from_circuit(circuit: &Circuit) -> Self {
+        Self::new(
+            circuit.num_private_inputs(),
+            circuit.layers.iter().map(CircuitLayer::logw).collect(),
+        )
+    }
+
+    pub(crate) fn new(num_private_inputs: usize, logw: Vec<usize>) -> Self {
+        Self {
+            num_private_inputs,
+            logw,
+        }
+    }
+
+    /// Indices of the witnesses for private inputs.
+    pub(crate) fn private_input_witness_indices(&self) -> Range<usize> {
+        0..self.num_private_inputs
+    }
+
+    /// Indices of the witnesses for `vl`, `vr` and `vl * vr` at the given layer.
+    pub(crate) fn wire_witness_indices(&self, layer: usize) -> (usize, usize, usize) {
+        assert!(layer < self.logw.len());
+
+        let start = self.num_private_inputs // skip past private inputs
+            // skip vl, vr, vl*vr for each layer except this one
+            + layer * 3
+            // skip the polynomials (2 elements, 2 hands) for each layer, including this one
+            + 2 * 2 * self.logw.iter().take(layer + 1).sum::<usize>();
+
+        // vl, vr and vl * vr are always adjacent in the witness vector.
+        (start, start + 1, start + 2)
+    }
+
+    /// Indices of the witnesses for the polynomial at the given layer, round and hand. There is a
+    /// witness for each of p0 and p2.
+    pub(crate) fn polynomial_witness_indices(
+        &self,
+        layer: usize,
+        round: usize,
+        hand: usize,
+    ) -> (usize, usize) {
+        assert!(layer < self.logw.len());
+        assert!(round < self.logw[layer]);
+        assert!(hand < 2);
+
+        let start = self.num_private_inputs // skip past private inputs
+            // skip vl, vr, vl*vr for each layer except this one
+            + layer * 3
+            // skip the polynomials (2 elements, 2 hands) for each layer except this one
+            + 2 * 2 * self.logw.iter().take(layer).sum::<usize>()
+            // skip the polynomials for each round except this one
+            + 2 * 2 * round
+            // skip the polynomials for each hand except this one
+            + 2 * hand;
+
+        // p0 and p2 are always adjacent in the witness vector
+        (start, start + 1)
+    }
+
+    /// Total length of the witness vector.
+    pub(crate) fn length(&self) -> usize {
+        self.num_private_inputs
+            // three wire witnesses per layer
+            + self.logw.len() * 3
+            // four polynomial witnesses per logw
+            + 4 * self.logw.iter().sum::<usize>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::catch_unwind;
+
+    use super::*;
+
+    #[test]
+    fn witness_layout() {
+        // private inputs:    private_input_0 | private_input_1 | private_input_2 |
+        // layer 0: logw = 0: vl | vr | vl * vr
+        // layer 1: logw = 3: p0_hand0_round0 | p2_hand0_round0 | p0_hand1_round0 | p2_hand1_round0
+        //                  | p0_hand0_round1 | p2_hand0_round1 | p0_hand1_round1 | p2_hand1_round1
+        //                  | p0_hand0_round2 | p2_hand0_round2 | p0_hand1_round2 | p2_hand1_round2
+        //                  | vl | vr | vl * vr
+        // layer 2: logw = 2: p0_hand0_round0 | p2_hand0_round0 | p0_hand1_round0 | p2_hand1_round0
+        //                  | p0_hand0_round1 | p2_hand0_round1 | p0_hand1_round1 | p2_hand1_round1
+        //                  | vl | vr | vl * vr
+        let layout = WitnessLayout::new(3, vec![0, 3, 2]);
+
+        assert_eq!(layout.private_input_witness_indices(), 0..3);
+
+        // Layer 0. No polynomials on layer 0.
+        catch_unwind(|| layout.polynomial_witness_indices(0, 0, 0)).unwrap_err();
+        assert_eq!(layout.wire_witness_indices(0), (3, 4, 5));
+
+        // Layer 1.
+        assert_eq!(layout.polynomial_witness_indices(1, 0, 0), (6, 7));
+        assert_eq!(layout.polynomial_witness_indices(1, 0, 1), (8, 9));
+        assert_eq!(layout.polynomial_witness_indices(1, 1, 0), (10, 11));
+        assert_eq!(layout.polynomial_witness_indices(1, 1, 1), (12, 13));
+        assert_eq!(layout.polynomial_witness_indices(1, 2, 0), (14, 15));
+        assert_eq!(layout.polynomial_witness_indices(1, 2, 1), (16, 17));
+        // Round 3 does not exist.
+        catch_unwind(|| layout.polynomial_witness_indices(1, 3, 0)).unwrap_err();
+        // Hand 2 does not exist
+        catch_unwind(|| layout.polynomial_witness_indices(1, 0, 2)).unwrap_err();
+        assert_eq!(layout.wire_witness_indices(1), (18, 19, 20));
+
+        // Layer 2.
+        assert_eq!(layout.polynomial_witness_indices(2, 0, 0), (21, 22));
+        assert_eq!(layout.polynomial_witness_indices(2, 0, 1), (23, 24));
+        assert_eq!(layout.polynomial_witness_indices(2, 1, 0), (25, 26));
+        assert_eq!(layout.polynomial_witness_indices(2, 1, 1), (27, 28));
+        // Round 2 does not exist.
+        catch_unwind(|| layout.polynomial_witness_indices(2, 2, 0)).unwrap_err();
+        assert_eq!(layout.wire_witness_indices(2), (29, 30, 31));
+
+        // Layer 3 does not exist.
+        catch_unwind(|| layout.polynomial_witness_indices(3, 0, 0)).unwrap_err();
+        catch_unwind(|| layout.wire_witness_indices(3)).unwrap_err();
+
+        assert_eq!(layout.length(), 32);
+    }
+}

--- a/test-vectors/README.md
+++ b/test-vectors/README.md
@@ -34,7 +34,11 @@ This test vector was generated using [`longfellow-zk/lib/zk/zk-test.cc`][rfc-1-t
 commit 87474f308020535e57a778a82394a14106f8be5b and the serializations for circuits, layers and
 quads at that version.
 
+The linear and quadratic constraints in the test vector were generated using
+[this branch][rfc-1-test-vector-constraints] of longfellow-zk.
+
 [rfc-1-test-vector]: https://github.com/google/longfellow-zk/blob/87474f308020535e57a778a82394a14106f8be5b/lib/zk/zk_test.cc
+[rfc-1-test-vector-constraints]: https://github.com/tgeoghegan/longfellow-zk/tree/constraint-test-vector
 
 ### `longfellow-mac-circuit-902a955fbb22323123aac5b69bdf3442e6ea6f80-1`
 

--- a/test-vectors/circuit/longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b.json
+++ b/test-vectors/circuit/longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b.json
@@ -3,5 +3,20 @@
     "field": 6,
     "depth": 3,
     "quads": 11,
-    "_terms": 11
+    "_terms": 11,
+    "valid_inputs": [45, 5, 6],
+    "invalid_inputs": [45, 5, 7],
+    "ligero_commitment": "007d7d268cf864fc51a7d46342958ced39636fad80847f1cc095150e96022f74",
+    "pad": 7,
+    "constraints": {
+        "linear_rhs": [
+            "28f3cced8eafdce4d724d78a04221b22",
+            "9b3b5b1948fd29133715b3ac3dbc3458",
+            "9840266098f822436c95e9f33370064d"
+        ],
+        "quadratic": [
+            { "x": 14, "y": 15, "z": 16 },
+            { "x": 25, "y": 26, "z": 27 }
+        ]
+    }
 }


### PR DESCRIPTION
We can't be certain that this works yet, because we don't yet have the Ligero prover set up which would produce a serialized proof we could compare against a test vector. Still, we can start code review. In parallel, I'm going to work on:

- making `sumcheck::Proof::new` also emit the actual witness vector, so that we can extend the test on `sumcheck::constraints::ProofConstraints` to check that the constraints it generated are consistent with witness values
- see if I can modify longfellow-zk to spit out a test vector of constraints (a vector of `(c, j, k)` triples for linear LHS, the b vector for linear RHS and a vector of `(x, y, z)` triples for the quad constraints) so we can test against that

I also suspect that in the near future, we'll want to move some modules or items out of the `sumcheck` module, because things like constraints and the witness layout will also be used by the Ligero prover and verifier. `longfellow-zk` has some of this stuff in a `zk-common` module, which could work for us.