### PR TITLE
Ligero commitment preliminaries

### DIFF
--- a/src/ligero/committer.rs
+++ b/src/ligero/committer.rs
@@ -1,3 +1,96 @@
-//! Ligero commiter, specified in [Section 4.3][1].
+//! Ligero committer, specified in [Section 4.3][1].
 //!
 //! [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-4.3
+
+use crate::{
+    constraints::proof_constraints::QuadraticConstraint, fields::FieldElement,
+    ligero::LigeroParameters, witness::Witness,
+};
+use anyhow::Context;
+
+/// A commitment to a witness vector, as specified in [1]. Concretely, this is the root of a Merkle
+/// tree of SHA-256 hashes.
+///
+/// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-4.3
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LigeroCommitment([u8; 32]);
+
+impl LigeroCommitment {
+    /// The commitment as a slice of bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// A fake but well-formed commitment for tests.
+    #[cfg(test)]
+    pub fn test_commitment() -> Self {
+        Self::try_from([1u8; 32].as_slice()).unwrap()
+    }
+}
+
+impl TryFrom<&[u8]> for LigeroCommitment {
+    type Error = anyhow::Error;
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let commitment: [u8; 32] = value
+            .try_into()
+            .context("byte slice wrong size for commitment")?;
+        Ok(LigeroCommitment(commitment))
+    }
+}
+
+impl LigeroCommitment {
+    /// Compute a Ligero commitment to the witness vector and the quadratic constraints. The layout
+    /// of the commitment is specified in [1].
+    ///
+    /// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-4.3
+    pub fn commit<FE: FieldElement>(
+        _parameters: &LigeroParameters,
+        _witness: &Witness<FE>,
+        _quadratic_constraints: &[QuadraticConstraint],
+    ) -> Result<Self, anyhow::Error> {
+        // Construct the tableau matrix from the witness and the constraints
+
+        // Construct a Merkle tree from the tableau
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        circuit::Evaluation,
+        constraints::proof_constraints::quadratic_constraints,
+        fields::fieldp128::FieldP128,
+        test_vector::CircuitTestVector,
+        witness::{Witness, WitnessLayout},
+    };
+
+    use super::*;
+
+    #[test]
+    #[ignore]
+    fn longfellow_rfc_1_87474f308020535e57a778a82394a14106f8be5b() {
+        let (test_vector, circuit) =
+            CircuitTestVector::decode("longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b");
+
+        let evaluation: Evaluation<FieldP128> = circuit
+            .evaluate(test_vector.valid_inputs.as_deref().unwrap())
+            .unwrap();
+
+        let quadratic_constraints = quadratic_constraints::<FieldP128>(&circuit);
+        let witness = Witness::fill_witness(
+            WitnessLayout::from_circuit(&circuit),
+            evaluation.private_inputs(circuit.num_public_inputs()),
+            || test_vector.pad().unwrap(),
+        );
+
+        let ligero_commitment = LigeroCommitment::commit::<FieldP128>(
+            test_vector.ligero_parameters.as_ref().unwrap(),
+            &witness,
+            &quadratic_constraints,
+        )
+        .unwrap();
+
+        assert_eq!(ligero_commitment, test_vector.ligero_commitment().unwrap());
+    }
+}

--- a/src/ligero/mod.rs
+++ b/src/ligero/mod.rs
@@ -2,7 +2,24 @@
 //!
 //! [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-4
 
+use serde::Deserialize;
+
 pub mod committer;
 pub mod merkle;
 pub mod prover;
 pub mod verifier;
+
+/// Common parameters for the Ligero proof system. Described in [Section 4.2][1].
+///
+/// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-4.2
+#[derive(Debug, Clone, Deserialize)]
+pub struct LigeroParameters {
+    /// The number of columns of the commitment matrix that the Verifier requests to be revealed by the Prover.
+    pub nreq: usize,
+    /// The number of witness values included in each row. Also "WR".
+    pub witnesses_per_row: usize,
+    /// The number of quadratic constraints written in each row. Also "QR".
+    pub quadratic_constraints_per_row: usize,
+    /// The size of each row, in terms of number of field elements. Also "BLOCK".
+    pub row_size: usize,
+}

--- a/src/test_vector.rs
+++ b/src/test_vector.rs
@@ -5,6 +5,7 @@ use crate::{
     circuit::Circuit,
     constraints::proof_constraints::QuadraticConstraint,
     fields::{CodecFieldElement, FieldElement},
+    ligero::{LigeroParameters, committer::LigeroCommitment},
 };
 use serde::Deserialize;
 use std::{
@@ -14,7 +15,7 @@ use std::{
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct Constraints {
-    /// Right hand side terms of lienar constraints (vector of serialzied field elements in
+    /// Right hand side terms of linear constraints (vector of serialzied field elements in
     /// hex).
     pub(crate) linear_rhs: Vec<String>,
     // Quadratic constraints.
@@ -64,6 +65,7 @@ pub(crate) struct CircuitTestVector {
     pub(crate) serialized_ligero_proof: Vec<u8>,
     /// The fixed pad value to use during constraint generation.
     pub(crate) pad: Option<u64>,
+    pub(crate) ligero_parameters: Option<LigeroParameters>,
 }
 
 impl CircuitTestVector {
@@ -112,9 +114,9 @@ impl CircuitTestVector {
         self.pad.map(|pad| FE::from_u128(pad.into()))
     }
 
-    pub(crate) fn ligero_commitment(&self) -> Option<Vec<u8>> {
-        self.ligero_commitment
-            .as_ref()
-            .map(|ref string| hex::decode(string).unwrap())
+    pub(crate) fn ligero_commitment(&self) -> Option<LigeroCommitment> {
+        self.ligero_commitment.as_ref().map(|ref string| {
+            LigeroCommitment::try_from(hex::decode(string).unwrap().as_slice()).unwrap()
+        })
     }
 }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -3,7 +3,10 @@
 //!
 //! <https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-00#section-3>
 
-use crate::{circuit::Circuit, fields::CodecFieldElement, sumcheck::Polynomial};
+use crate::{
+    circuit::Circuit, fields::CodecFieldElement, ligero::committer::LigeroCommitment,
+    sumcheck::Polynomial,
+};
 use aes::{
     Aes256,
     cipher::{BlockEncrypt, KeyInit},
@@ -74,7 +77,7 @@ impl Transcript {
     /// match longfellow-zk.
     pub fn initialize<FE: CodecFieldElement>(
         &mut self,
-        ligero_commitment: &[u8],
+        ligero_commitment: &LigeroCommitment,
         circuit: &Circuit,
         public_inputs: &[FE],
     ) -> Result<(), anyhow::Error> {
@@ -83,7 +86,7 @@ impl Transcript {
         // https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-3.1.3
         // 3.1.3 item 1 says to append the "Prover message", "which is usually a commitment". In
         // particular, a Ligero commitment.
-        self.write_byte_array(ligero_commitment)?;
+        self.write_byte_array(ligero_commitment.as_bytes())?;
 
         // 3.1.3 item 2: write circuit ID
         self.write_byte_array(&circuit.id)?;

--- a/test-vectors/circuit/longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b.json
+++ b/test-vectors/circuit/longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b.json
@@ -4,6 +4,13 @@
     "depth": 3,
     "quads": 11,
     "_terms": 11,
+    "ligero_parameters":{
+        "nreq": 6,
+        "rate": 4,
+        "witnesses_per_row": 20,
+        "quadratic_constraints_per_row": 2,
+        "row_size": 51
+    },
     "valid_inputs": [45, 5, 6],
     "invalid_inputs": [45, 5, 7],
     "pad": 2,


### PR DESCRIPTION
Various things we will need for Ligero commitments.

Computing a sumcheck proof or generating Ligero linear constraints from a sumcheck proof requires the Ligero commitment. Computing the commitment requires the quadratic constraints and the witness. We refactor the Sumcheck prover so that the witness can be computed independently (using the new `witness::Witness`) and the constraint builder so that it can compute quadratic constraints separately from the linear (using the new `constraints::quadratic_constraints` function).

Introduce a type `LigeroCommitment` wrapping a byte array with some convenience methods on it.

Set up a test for Ligero commitment that currently fails.