### PR TITLE
Ligero commitment to witnesses

### DIFF
--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -200,6 +200,18 @@ pub trait LagrangePolynomialFieldElement: FieldElement {
     }
 }
 
+pub fn field_element_iter<FE: CodecFieldElement>() -> impl Iterator<Item = FE> {
+    std::iter::from_fn(|| Some(FE::sample()))
+}
+
+pub fn field_element_iter_from_source<F, FE>(mut source: F) -> impl Iterator<Item = FE>
+where
+    FE: CodecFieldElement,
+    F: FnMut() -> FE,
+{
+    std::iter::from_fn(move || Some(source()))
+}
+
 /// Field identifier. According to the draft specification, the encoding is of variable length ([1])
 /// but in the Longfellow implementation ([2]), they're always 3 bytes long.
 ///

--- a/src/ligero/merkle.rs
+++ b/src/ligero/merkle.rs
@@ -16,6 +16,18 @@ impl From<[u8; 32]> for Node {
     }
 }
 
+impl From<Sha256> for Node {
+    fn from(hash: Sha256) -> Self {
+        Self::from(<[u8; 32]>::from(hash.finalize()))
+    }
+}
+
+impl From<Node> for [u8; 32] {
+    fn from(value: Node) -> Self {
+        value.0
+    }
+}
+
 /// An inclusion proof from a Merkle tree.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Proof(Vec<Node>);

--- a/src/ligero/mod.rs
+++ b/src/ligero/mod.rs
@@ -4,6 +4,8 @@
 
 use serde::Deserialize;
 
+use crate::fields::LagrangePolynomialFieldElement;
+
 pub mod committer;
 pub mod merkle;
 pub mod prover;
@@ -21,5 +23,126 @@ pub struct LigeroParameters {
     /// The number of quadratic constraints written in each row. Also "QR".
     pub quadratic_constraints_per_row: usize,
     /// The size of each row, in terms of number of field elements. Also "BLOCK".
+    /// There is some confusion in the specification between this and NCOL.
     pub row_size: usize,
+    /// The total size of a tableau row.
+    /// There is some confusion in the specification between this and BLOCK.
+    pub num_columns: u128,
+}
+
+impl LigeroParameters {
+    /// DBLOCK, 2 * BLOCK - 1
+    pub fn dblock(&self) -> usize {
+        self.row_size * 2 - 1
+    }
+}
+
+/// The extend method, as defined in [2.2.1][1]. We interpolate a polynomial of degree at most
+/// `nodes.len() - 1` from the provided evaluations at points `[0..nodes.len())` and then evaluate
+/// that polynomial at `[0, evaluations)`.
+///
+/// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-2.2.1
+pub fn extend<FE: LagrangePolynomialFieldElement>(nodes: &[FE], evaluations: u128) -> Vec<FE> {
+    // For now we use the relatively straightforward method of computing Lagrange basis polynomials
+    // for each provided point.
+    //
+    // https://en.wikipedia.org/wiki/Lagrange_polynomial#Definition
+    let mut output = Vec::with_capacity(evaluations as usize);
+    let mut denominators = vec![None; nodes.len()];
+
+    for input in (0..evaluations).map(FE::from_u128) {
+        let mut eval = FE::ZERO;
+
+        // Evaluate each basis polynomial
+        for (node_x_coordinate, node_y_coordinate) in nodes.iter().enumerate() {
+            // Compute and cache denominators
+            let denominator = match denominators[node_x_coordinate] {
+                Some(denominator) => denominator,
+                None => {
+                    let denominator = nodes
+                        .iter()
+                        .enumerate()
+                        .filter(|(other_node_x_coordinate, _)| {
+                            *other_node_x_coordinate != node_x_coordinate
+                        })
+                        .fold(FE::ONE, |product, (other_node_x_coordinate, _)| {
+                            product
+                                * (FE::from_u128(node_x_coordinate as u128)
+                                    - FE::from_u128(other_node_x_coordinate as u128))
+                        })
+                        .mul_inv();
+                    denominators[node_x_coordinate] = Some(denominator);
+                    denominator
+                }
+            };
+
+            // Compute each term of the basis polynomial
+            let basis_poly_eval = nodes
+                .iter()
+                .enumerate()
+                .filter(|(other_node_x_coordinate, _)| {
+                    *other_node_x_coordinate != node_x_coordinate
+                })
+                .fold(FE::ONE, |product, (other_node_x_coordinate, _)| {
+                    product * (input - FE::from_u128(other_node_x_coordinate as u128))
+                })
+                * *node_y_coordinate
+                * denominator;
+            eval += basis_poly_eval;
+        }
+
+        output.push(eval);
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fields::{
+        field2_128::Field2_128, fieldp128::FieldP128, fieldp256::FieldP256, fieldp521::FieldP521,
+    };
+
+    fn extend_x_2<FE: LagrangePolynomialFieldElement>() {
+        let output = extend(
+            // x^2 evaluated at 0, 1, 2 => 0, 1, 4
+            &[FE::ZERO, FE::ONE, FE::from_u128(4)],
+            6,
+        );
+
+        assert_eq!(
+            output,
+            // x^2 evaluated at 0..6 = > 0, 1, 4, 9, 16, 25
+            vec![
+                FE::ZERO,
+                FE::ONE,
+                FE::from_u128(4),
+                FE::from_u128(9),
+                FE::from_u128(16),
+                FE::from_u128(25),
+            ]
+        );
+    }
+
+    #[test]
+    fn extend_x_2_p128() {
+        extend_x_2::<FieldP128>();
+    }
+
+    #[test]
+    fn extend_x_2_p256() {
+        extend_x_2::<FieldP256>();
+    }
+
+    #[test]
+    fn extend_x_2_p521() {
+        extend_x_2::<FieldP521>();
+    }
+
+    #[ignore]
+    #[test]
+    fn extend_x_2_2_128() {
+        extend_x_2::<Field2_128>();
+    }
 }

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -109,6 +109,11 @@ pub struct Witness<FieldElement> {
 }
 
 impl<FE: FieldElement> Witness<FE> {
+    /// Number of field elements in the witness.
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
     /// Construct a witness vector for the layout, generating pad values.
     pub fn fill_witness<PadGenerator: FnMut() -> FE>(
         layout: WitnessLayout,
@@ -162,6 +167,16 @@ impl<FE: FieldElement> Witness<FE> {
     /// Get an element of the witness.
     pub fn element(&self, index: usize) -> FE {
         self.values[index]
+    }
+
+    /// Get an iterator over a range of witnesses, or zeroes if the witness index is undefined.
+    pub fn elements(&self, start: usize, count: usize) -> impl Iterator<Item = FE> {
+        self.values
+            .iter()
+            .skip(start)
+            .copied()
+            .chain(std::iter::repeat(FE::ZERO))
+            .take(count)
     }
 }
 

--- a/test-vectors/circuit/longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b.json
+++ b/test-vectors/circuit/longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b.json
@@ -7,9 +7,10 @@
     "ligero_parameters":{
         "nreq": 6,
         "rate": 4,
-        "witnesses_per_row": 20,
+        "witnesses_per_row": 15,
         "quadratic_constraints_per_row": 2,
-        "row_size": 51
+        "row_size": 21,
+        "num_columns": 128
     },
     "valid_inputs": [45, 5, 6],
     "invalid_inputs": [45, 5, 7],


### PR DESCRIPTION
Construct a Ligero commitment to the witnesses by constructing the tableau matrix, then building a Merkle tree from columns of that matrix. The commitment is the root of the tree.

To construct tableau rows, we need the `extend` method from 2.2.1. This is implemented by evaluating and summing Lagrange basis polynomials.