### PR TITLE
Specialize squaring in GF(2^128)

### DIFF
--- a/src/fields/field2_128/backend_aarch64.rs
+++ b/src/fields/field2_128/backend_aarch64.rs
@@ -17,6 +17,30 @@ pub(super) fn galois_multiply(x: u128, y: u128) -> u128 {
     let result_low = product1 ^ middle_low;
     let result_high = product4 ^ middle_high;
 
+    reduce(result_low, result_high)
+}
+
+/// Squares a GF(2^128) element, represented as a `u128`.
+#[target_feature(enable = "neon")]
+#[target_feature(enable = "aes")]
+pub(super) fn galois_square(x: u128) -> u128 {
+    // Perform carryless multiplication using schoolbook multiplication and the PMULL instruction.
+    //
+    // In the terms of the variables used by `galois_multiply()`, we know when squaring that
+    // `product2` and `product3` will be equal. Therefore, `middle` will be zero, since the field
+    // has characteristic two and `product2` and `product3` cancel out.
+    let product1 = vmull_p64(x as u64, x as u64);
+    let product4 = vmull_p64((x >> 64) as u64, (x >> 64) as u64);
+    let result_low = product1;
+    let result_high = product4;
+
+    reduce(result_low, result_high)
+}
+
+/// Reduce an intermediate 256-bit product by the field's quotient polynomial.
+#[target_feature(enable = "neon")]
+#[target_feature(enable = "aes")]
+fn reduce(result_low: u128, result_high: u128) -> u128 {
     // Perform the first step of the reduction by x^128 + x^7 + x^2 + x + 1. Shift the upper u128 of
     // the product several times, and XOR it with the lower u128 of the product.
     let shifted_1 = result_high << 1;

--- a/src/fields/field2_128/backend_bit_slicing.rs
+++ b/src/fields/field2_128/backend_bit_slicing.rs
@@ -8,6 +8,22 @@ pub(super) fn galois_multiply(x: u128, y: u128) -> u128 {
     // Produce a 255-bit carryless multiplication product.
     let product = clmul128(x, y);
 
+    reduce(product)
+}
+
+/// Squares a GF(2^128) element, represented as a `u128`.
+///
+/// This fallback implementation uses SIMD-within-a-register techniques. It combines bit slicing
+/// with integer multiplication to implement carryless multiplication.
+pub(super) fn galois_square(x: u128) -> u128 {
+    // Produce a 255-bit carryless multiplication product.
+    let product = clmul128_square(x);
+
+    reduce(product)
+}
+
+/// Reduce an intermediate 256-bit product by the field's quotient polynomial.
+fn reduce(product: U256) -> u128 {
     // Reduce the result by x^128 + x^7 + x^2 + x + 1.
     //
     // First we multiply the upper u128 of the product, all of which has a factor of x^128 in it, by
@@ -35,6 +51,12 @@ pub(super) fn galois_multiply(x: u128, y: u128) -> u128 {
         ^ (first_reduction.high << 7)
 }
 
+const MASK_0: u128 = 0x21084210842108421084210842108421;
+const MASK_1: u128 = 0x42108421084210842108421084210842;
+const MASK_2: u128 = 0x84210842108421084210842108421084;
+const MASK_3: u128 = 0x08421084210842108421084210842108;
+const MASK_4: u128 = 0x10842108421084210842108421084210;
+
 /// Carryless multiplication of two 64-bit arguments.
 fn clmul64(x: u64, y: u64) -> u128 {
     // This uses the technique outlined in
@@ -42,12 +64,6 @@ fn clmul64(x: u64, y: u64) -> u128 {
     // multiplications on masked arguments are used to build up a carryless multiplication. All bits
     // except every fifth are masked off, so that the carries that accumulate during one integer
     // multiply won't interfere with the LSB of the next group of five bits in the integer product.
-
-    const MASK_0: u128 = 0x21084210842108421084210842108421;
-    const MASK_1: u128 = 0x42108421084210842108421084210842;
-    const MASK_2: u128 = 0x84210842108421084210842108421084;
-    const MASK_3: u128 = 0x08421084210842108421084210842108;
-    const MASK_4: u128 = 0x10842108421084210842108421084210;
 
     let x0 = (x & (MASK_0 as u64)) as u128;
     let x1 = (x & (MASK_1 as u64)) as u128;
@@ -65,6 +81,27 @@ fn clmul64(x: u64, y: u64) -> u128 {
     let z2 = ((x0 * y2) ^ (x1 * y1) ^ (x2 * y0) ^ (x3 * y4) ^ (x4 * y3)) & MASK_2;
     let z3 = ((x0 * y3) ^ (x1 * y2) ^ (x2 * y1) ^ (x3 * y0) ^ (x4 * y4)) & MASK_3;
     let z4 = ((x0 * y4) ^ (x1 * y3) ^ (x2 * y2) ^ (x3 * y1) ^ (x4 * y0)) & MASK_4;
+
+    z0 | z1 | z2 | z3 | z4
+}
+
+/// Carryless multiplication of one 64-bit argument by itself.
+fn clmul64_square(x: u64) -> u128 {
+    // Note that most of the terms in `clmul64()` cancel out when x = y, in the case of squaring.
+    // This results in a much simpler formula. In fact, the even bits of the output directly
+    // correspond to all the bits of the input.
+
+    let x0 = (x & (MASK_0 as u64)) as u128;
+    let x1 = (x & (MASK_1 as u64)) as u128;
+    let x2 = (x & (MASK_2 as u64)) as u128;
+    let x3 = (x & (MASK_3 as u64)) as u128;
+    let x4 = (x & (MASK_4 as u64)) as u128;
+
+    let z0 = (x0 * x0) & MASK_0;
+    let z1 = (x3 * x3) & MASK_1;
+    let z2 = (x1 * x1) & MASK_2;
+    let z3 = (x4 * x4) & MASK_3;
+    let z4 = (x2 * x2) & MASK_4;
 
     z0 | z1 | z2 | z3 | z4
 }
@@ -97,6 +134,17 @@ fn clmul128(x: u128, y: u128) -> U256 {
     U256 {
         low: r1 ^ (t << 64),
         high: (t >> 64) ^ r4,
+    }
+}
+
+/// Carryless multiplication of one 128-bit argument by itself.
+fn clmul128_square(x: u128) -> U256 {
+    // This uses schoolbook multiplication. Since we are squaring in a field of characteristic two,
+    // terms that arise from multiplying the low half of the input by the high half of the input (or
+    // vice versa) appear twice, and therefore cancel themselves out.
+    U256 {
+        high: clmul64_square((x >> 64) as u64),
+        low: clmul64_square(x as u64),
     }
 }
 

--- a/src/fields/field2_128/backend_naive_loop.rs
+++ b/src/fields/field2_128/backend_naive_loop.rs
@@ -45,3 +45,10 @@ fn decompose(value: u128) -> [bool; 128] {
     }
     bits
 }
+
+/// Squares a GF(2^128) element, represented as a `u128`.
+///
+/// This is a very slow implementation of multiplication, using arrays of booleans and loops.
+pub(super) fn galois_square(x: u128) -> u128 {
+    galois_multiply(x, x)
+}


### PR DESCRIPTION
This adds separate squaring methods to each GF(2^128) backend. Squaring is significantly easier than multiplying, because we can break down a u128-by-u128 carryless multiplication into two u64-by-u64 carryless multiplications, instead of three or four. The following reduction is the same as in the more general multiplication case, so I extracted that into separate functions. Closes #53.