### PR TITLE
Various Ligero prover preliminaries

### DIFF
--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -117,6 +117,27 @@ pub trait CodecFieldElement:
 
         (field_element, rejections)
     }
+
+    /// Whether or not this field element fits in the subfield associated with the field.
+    fn fits_in_subfield(&self) -> bool {
+        // For now, we only support fields where the subfield and the field are the same.
+        true
+    }
+
+    /// Encode this element as an element of the subfield associated with the field.
+    fn encode_in_subfield(&self, bytes: &mut Vec<u8>) -> Result<(), anyhow::Error> {
+        // For now, we only support fields where the subfield and the field are the same.
+        self.encode(bytes)
+    }
+
+    /// Decode a fixed length array of elements from the subfield into the field.
+    fn decode_fixed_array_in_subfield(
+        bytes: &mut Cursor<&[u8]>,
+        count: usize,
+    ) -> Result<Vec<Self>, anyhow::Error> {
+        // For now, we only support fields where the subfield and the field are the same.
+        Self::decode_fixed_array(bytes, count)
+    }
 }
 
 /// Elements of a field in which we can interpolate polynomials up to degree two. Our nodes are

--- a/src/ligero/committer.rs
+++ b/src/ligero/committer.rs
@@ -6,7 +6,7 @@ use crate::{
     constraints::proof_constraints::QuadraticConstraint,
     fields::{CodecFieldElement, LagrangePolynomialFieldElement, field_element_iter_from_source},
     ligero::{
-        LigeroParameters, extend,
+        TableauLayout, extend,
         merkle::{MerkleTree, Node},
     },
     witness::Witness,
@@ -21,19 +21,6 @@ use sha2::{Digest, Sha256};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LigeroCommitment([u8; 32]);
 
-impl LigeroCommitment {
-    /// The commitment as a slice of bytes.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-
-    /// A fake but well-formed commitment for tests.
-    #[cfg(test)]
-    pub fn test_commitment() -> Self {
-        Self::try_from([1u8; 32].as_slice()).unwrap()
-    }
-}
-
 impl TryFrom<&[u8]> for LigeroCommitment {
     type Error = anyhow::Error;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
@@ -45,6 +32,17 @@ impl TryFrom<&[u8]> for LigeroCommitment {
 }
 
 impl LigeroCommitment {
+    /// The commitment as a slice of bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// A fake but well-formed commitment for tests.
+    #[cfg(test)]
+    pub fn test_commitment() -> Self {
+        Self::try_from([1u8; 32].as_slice()).unwrap()
+    }
+
     /// Compute a Ligero commitment to the witness vector and the quadratic constraints. The layout
     /// of the commitment is specified in [1].
     ///
@@ -52,7 +50,7 @@ impl LigeroCommitment {
     ///
     /// This function could probably allocate a whole lot less by allocating vecs up front.
     pub fn commit<FE, TableauGenerator, MerkleTreeNonceGenerator>(
-        parameters: &LigeroParameters,
+        tableau_layout: &TableauLayout,
         witness: &Witness<FE>,
         quadratic_constraints: &[QuadraticConstraint],
         tableau_generator: TableauGenerator,
@@ -64,14 +62,11 @@ impl LigeroCommitment {
         MerkleTreeNonceGenerator: FnMut() -> [u8; 32],
     {
         // Rows for the witnesses, but not the quadratic constraints
-        let num_witness_rows = witness.len().div_ceil(parameters.witnesses_per_row);
+        let num_witness_rows = tableau_layout.num_linear_constraint_rows();
         // Each quadratic constraint contributes three witnesses
-        let num_quadratic_rows = 3 * quadratic_constraints
-            .len()
-            .div_ceil(parameters.witnesses_per_row);
+        let num_quadratic_rows = tableau_layout.num_quadratic_rows();
         // Rows for low degree test, linear test and quadratic test
-        let expected_tableau_size = 3 + num_witness_rows + num_quadratic_rows;
-        let mut tableau = Vec::with_capacity(expected_tableau_size);
+        let mut tableau = Vec::with_capacity(tableau_layout.num_rows());
 
         let mut element_generator = field_element_iter_from_source(tableau_generator);
 
@@ -79,18 +74,18 @@ impl LigeroCommitment {
         // Fill the low degree test row: extend(RANDOM[BLOCK], BLOCK, NCOL)
         let base_row = element_generator
             .by_ref()
-            .take(parameters.row_size)
+            .take(tableau_layout.block_size())
             .collect::<Vec<_>>();
-        tableau.push(extend(&base_row, parameters.num_columns));
+        tableau.push(extend(&base_row, tableau_layout.num_columns()));
 
         // Fill the linear test row ("IDOT"): random field elements where elements [nreq..nreq+wr)
         // sum to 0, extended to NCOL
         let mut sum = FE::ZERO;
         let mut index = 0;
-        let mut row_random_elements = element_generator.by_ref().take(parameters.dblock() - 1);
+        let mut row_random_elements = element_generator.by_ref().take(tableau_layout.dblock() - 1);
 
         let mut z: Vec<_> = std::iter::from_fn(|| {
-            let element = if index == parameters.nreq {
+            let element = if index == tableau_layout.nreq() {
                 // Reserve the first witness spot for the additive inverse of the sum of the
                 // remaining witnesses. Per the spec we could put this element anywhere in the
                 // witnesses, but this matches longfellow-zk and makes it easier to test against
@@ -98,7 +93,8 @@ impl LigeroCommitment {
                 Some(FE::ZERO)
             } else {
                 let element = row_random_elements.next();
-                if (parameters.nreq + 1..parameters.nreq + parameters.witnesses_per_row)
+                if (tableau_layout.nreq() + 1
+                    ..tableau_layout.nreq() + tableau_layout.witnesses_per_row())
                     .contains(&index)
                 {
                     // Unwrap safety: the iterator should contain exactly the number of elements we
@@ -111,28 +107,28 @@ impl LigeroCommitment {
             index += 1;
             element
         })
-        .take(parameters.dblock())
+        .take(tableau_layout.dblock())
         .collect();
 
-        z[parameters.nreq] = -sum;
+        z[tableau_layout.nreq()] = -sum;
         // Specification interpretation verification: we should have consumed row_random_elements
         assert_eq!(row_random_elements.next(), None);
         // Specification interpretation verification: make sure range nreq..nreq+wr sums to 0.
         assert_eq!(
             FE::ZERO,
             z.iter()
-                .skip(parameters.nreq)
-                .take(parameters.witnesses_per_row)
+                .skip(tableau_layout.nreq())
+                .take(tableau_layout.witnesses_per_row())
                 .fold(FE::ZERO, |acc, elem| acc + elem)
         );
-        tableau.push(extend(&z, parameters.num_columns));
+        tableau.push(extend(&z, tableau_layout.num_columns()));
 
         // Quadratic test row: NREQ random elements then zeroes for each witness, then more random
         // elements to fill to DBLOCK, then extended to NCOL
         let mut index = 0;
         let zq: Vec<_> = std::iter::from_fn(|| {
-            let next = if index < parameters.nreq
-                || index >= parameters.nreq + parameters.witnesses_per_row
+            let next = if index < tableau_layout.nreq()
+                || index >= tableau_layout.nreq() + tableau_layout.witnesses_per_row()
             {
                 element_generator.next()
             } else {
@@ -142,9 +138,9 @@ impl LigeroCommitment {
             index += 1;
             next
         })
-        .take(parameters.dblock())
+        .take(tableau_layout.dblock())
         .collect();
-        tableau.push(extend(zq.as_slice(), parameters.num_columns));
+        tableau.push(extend(zq.as_slice(), tableau_layout.num_columns()));
 
         // Padded witness rows: NREQ random elements, then witnesses_per_row elements of the witness
         // extended to NCOL
@@ -152,14 +148,14 @@ impl LigeroCommitment {
             tableau.push(extend(
                 element_generator
                     .by_ref()
-                    .take(parameters.nreq)
+                    .take(tableau_layout.nreq())
                     .chain(witness.elements(
-                        witness_row * parameters.witnesses_per_row,
-                        parameters.witnesses_per_row,
+                        witness_row * tableau_layout.witnesses_per_row(),
+                        tableau_layout.witnesses_per_row(),
                     ))
                     .collect::<Vec<_>>()
                     .as_slice(),
-                parameters.num_columns,
+                tableau_layout.num_columns(),
             ));
         }
 
@@ -171,10 +167,10 @@ impl LigeroCommitment {
         let mut quad_constraint_z = quadratic_constraints.iter().map(|q| q.z);
 
         for quad_constraint_row in 0..num_quadratic_rows {
-            let mut row = Vec::with_capacity(parameters.row_size);
-            row.extend(element_generator.by_ref().take(parameters.nreq));
+            let mut row = Vec::with_capacity(tableau_layout.block_size());
+            row.extend(element_generator.by_ref().take(tableau_layout.nreq()));
 
-            for _ in 0..parameters.witnesses_per_row {
+            for _ in 0..tableau_layout.witnesses_per_row() {
                 let witness = match quad_constraint_row % 3 {
                     0 => quad_constraint_x.next(),
                     1 => quad_constraint_y.next(),
@@ -186,27 +182,32 @@ impl LigeroCommitment {
                 row.push(witness);
             }
 
-            tableau.push(extend(row.as_slice(), parameters.num_columns));
+            tableau.push(extend(row.as_slice(), tableau_layout.num_columns()));
         }
 
         // Make sure we allocated the tableau correctly up front.
-        assert_eq!(tableau.len(), expected_tableau_size);
+        assert_eq!(tableau.len(), tableau_layout.num_rows());
 
         // Construct a Merkle tree from the tableau columns
         let mut field_element_buf = Vec::with_capacity(FE::num_bytes());
-        let mut tree = MerkleTree::new(parameters.num_columns as usize - parameters.dblock());
-        for leaf_index in parameters.dblock()..(parameters.num_columns as usize) {
+        let tree_size = tableau_layout.num_columns() - tableau_layout.dblock();
+        let mut tree = MerkleTree::new(tree_size);
+        let mut merkle_tree_nonces = Vec::with_capacity(tree_size);
+
+        for leaf_index in tableau_layout.dblock()..(tableau_layout.num_columns()) {
             let mut sha256 = Sha256::new();
 
             // longfellow-zk hashes a random nonce into each leaf before the tableau elements, which
             // is not discussed in the draft specification.
-            sha256.update(merkle_tree_nonce_generator());
+            let nonce = merkle_tree_nonce_generator();
+            merkle_tree_nonces.push(nonce);
+            sha256.update(nonce);
             for row in &tableau {
                 field_element_buf.truncate(0);
                 row[leaf_index].encode(&mut field_element_buf)?;
                 sha256.update(&field_element_buf);
             }
-            tree.set_leaf(leaf_index - parameters.dblock(), Node::from(sha256));
+            tree.set_leaf(leaf_index - tableau_layout.dblock(), Node::from(sha256));
         }
         tree.build();
 
@@ -234,7 +235,7 @@ mod tests {
             .evaluate(test_vector.valid_inputs.as_deref().unwrap())
             .unwrap();
 
-        let quadratic_constraints = quadratic_constraints::<FieldP128>(&circuit);
+        let quadratic_constraints = quadratic_constraints(&circuit);
         let witness = Witness::fill_witness(
             WitnessLayout::from_circuit(&circuit),
             evaluation.private_inputs(circuit.num_public_inputs()),
@@ -246,8 +247,14 @@ mod tests {
         let mut merkle_tree_nonce = [0; 32];
         merkle_tree_nonce[0] = test_vector.pad.unwrap() as u8;
 
-        let ligero_commitment = LigeroCommitment::commit::<FieldP128, _, _>(
+        let tableau_layout = TableauLayout::new(
             test_vector.ligero_parameters.as_ref().unwrap(),
+            witness.len(),
+            quadratic_constraints.len(),
+        );
+
+        let ligero_commitment = LigeroCommitment::commit::<FieldP128, _, _>(
+            &tableau_layout,
             &witness,
             &quadratic_constraints,
             || test_vector.pad().unwrap(),

--- a/src/ligero/merkle.rs
+++ b/src/ligero/merkle.rs
@@ -30,7 +30,7 @@ impl From<Node> for [u8; 32] {
 
 /// An inclusion proof from a Merkle tree.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct Proof(Vec<Node>);
+pub struct InclusionProof(Vec<Node>);
 
 /// A Merkle tree of digests, enabling proofs that some digest is a leaf of the tree.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -116,7 +116,7 @@ impl MerkleTree {
 
     /// Prove that all the requested leaves are included in the tree. The indices are into the leaf
     /// layer of the tree.
-    pub fn prove(&self, requested_leaves: &[usize]) -> Proof {
+    pub fn prove(&self, requested_leaves: &[usize]) -> InclusionProof {
         let marked = Self::mark_tree(self.tree_size(), self.leaf_count(), requested_leaves);
 
         let mut proof = Vec::new();
@@ -133,7 +133,7 @@ impl MerkleTree {
             }
         }
 
-        Proof(proof)
+        InclusionProof(proof)
     }
 
     /// Verify that the `proof` proves that the `included_nodes` (each consisting of a digest and
@@ -143,7 +143,7 @@ impl MerkleTree {
         leaf_count: usize,
         included_nodes: &[Node],
         included_node_indices: &[usize],
-        proof: &Proof,
+        proof: &InclusionProof,
     ) -> Result<(), anyhow::Error> {
         if included_nodes.len() != included_node_indices.len() {
             return Err(anyhow!("lengths of nodes and node indices must match"));

--- a/src/test_vector.rs
+++ b/src/test_vector.rs
@@ -65,6 +65,7 @@ pub(crate) struct CircuitTestVector {
     pub(crate) serialized_ligero_proof: Vec<u8>,
     /// The fixed pad value to use during constraint generation.
     pub(crate) pad: Option<u64>,
+    /// Parameters for the Ligero proof.
     pub(crate) ligero_parameters: Option<LigeroParameters>,
 }
 

--- a/test-vectors/circuit/longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b.json
+++ b/test-vectors/circuit/longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b.json
@@ -9,7 +9,7 @@
         "rate": 4,
         "witnesses_per_row": 15,
         "quadratic_constraints_per_row": 2,
-        "row_size": 21,
+        "block_size": 21,
         "num_columns": 128
     },
     "valid_inputs": [45, 5, 6],


### PR DESCRIPTION
Various changes we will need in order to do Ligero proofs.

- introduce `TableauLayout`, which encapsulates various calculations for the layout of tableau rows based on the Ligero parameters, the size of the witness vector and the number of constraints. We also rename and document various fields of `LigeroParameters` for clarity.
- Rename various `Proof` and `Prover` structs to clarify which kind of proof they are, since we'll soon be using them all together.
- Skeletal support for subfields. In Longfellow, only GF(2^128) actually has a distinct subfield. Since we're currently only proving circuits using `FieldP128`, we can get away with pretending field and subfield are always the same. but we do add trait methods that will let us wire up the subfield stuff layer.
- Sample natural numbers from a `Transcript`, using the algorithm added in https://github.com/google/longfellow-zk/pull/91