### PR TITLE
Fix order of nonces in Ligero proof

### DIFF
--- a/src/ligero/prover.rs
+++ b/src/ligero/prover.rs
@@ -196,13 +196,10 @@ impl LigeroProver {
             .map(|c| c.to_vec())
             .collect();
 
-        let merkle_tree_nonces = merkle_tree
-            .nonces()
+        // Gather nonces for requested columns.
+        let merkle_tree_nonces = requested_column_indices
             .iter()
-            .copied()
-            .enumerate()
-            .filter(|(index, _)| requested_column_indices.contains(index))
-            .map(|(_, nonce)| nonce)
+            .map(|index| merkle_tree.nonces()[*index])
             .collect();
 
         let inclusion_proof = merkle_tree.prove(requested_column_indices.as_slice());


### PR DESCRIPTION
This fixes a bug in the Ligero prover. Based on inspection of the C++ implementation, we need to store nonces for opened columns in the same order as the columns themselves, in the order given by the challenge indices. The verifier already expects corresponding indices in the opened columns and the nonces to go together, so this bug caused proofs to be rejected when using unique nonces, and was missed by tests using `020000...` for all nonces.

(Cherry-picked from #69)