### PR TITLE
More code cleanup

### DIFF
--- a/src/constraints/proof_constraints.rs
+++ b/src/constraints/proof_constraints.rs
@@ -7,7 +7,7 @@ use crate::{
     circuit::Circuit,
     constraints::symbolic::{SymbolicExpression, Term},
     fields::{CodecFieldElement, LagrangePolynomialFieldElement},
-    ligero::committer::LigeroCommitment,
+    ligero::LigeroCommitment,
     sumcheck::{
         bind::{ElementwiseSum, SumcheckArray, bindeq},
         prover::SumcheckProof,

--- a/src/fields/field2_128/mod.rs
+++ b/src/fields/field2_128/mod.rs
@@ -78,6 +78,12 @@ impl LagrangePolynomialFieldElement for Field2_128 {
         // FieldP256::mul_inv() for an explanation of this technique.
         addition_chains::gf_2_128_m2::exp(*self)
     }
+
+    fn extend(_: &[Self], _: usize) -> Vec<Self> {
+        // Opt out of the default implementation which does not work for this field.
+        // https://github.com/abetterinternet/zk-cred-longfellow/issues/56
+        unimplemented!()
+    }
 }
 
 impl Debug for Field2_128 {

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -219,6 +219,69 @@ pub trait LagrangePolynomialFieldElement: FieldElement {
 
         out
     }
+
+    /// The extend method, as defined in [2.2.1][1] and [2.2.2][2]. We interpolate a polynomial of
+    /// degree at most `nodes.len() - 1` from the provided evaluations at points `[0..nodes.len())`
+    /// and then evaluate that polynomial at `[0, evaluations)`.
+    ///
+    /// The default implementation only works for large characteristic fields.
+    ///
+    /// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-2.2.1
+    /// [2]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-2.2.2
+    fn extend(nodes: &[Self], evaluations: usize) -> Vec<Self> {
+        // For now we use the relatively straightforward method of computing Lagrange basis polynomials
+        // for each provided point.
+        //
+        // https://en.wikipedia.org/wiki/Lagrange_polynomial#Definition
+        let mut output = Vec::with_capacity(evaluations);
+        let mut denominators = vec![None; nodes.len()];
+
+        for input in (0..evaluations).map(|e| Self::from_u128(e as u128)) {
+            let mut eval = Self::ZERO;
+
+            // Evaluate each basis polynomial
+            for (node_x_coordinate, node_y_coordinate) in nodes.iter().enumerate() {
+                // Compute and cache denominators
+                let denominator = match denominators[node_x_coordinate] {
+                    Some(denominator) => denominator,
+                    None => {
+                        let denominator = nodes
+                            .iter()
+                            .enumerate()
+                            .filter(|(other_node_x_coordinate, _)| {
+                                *other_node_x_coordinate != node_x_coordinate
+                            })
+                            .fold(Self::ONE, |product, (other_node_x_coordinate, _)| {
+                                product
+                                    * (Self::from_u128(node_x_coordinate as u128)
+                                        - Self::from_u128(other_node_x_coordinate as u128))
+                            })
+                            .mul_inv();
+                        denominators[node_x_coordinate] = Some(denominator);
+                        denominator
+                    }
+                };
+
+                // Compute each term of the basis polynomial
+                let basis_poly_eval = nodes
+                    .iter()
+                    .enumerate()
+                    .filter(|(other_node_x_coordinate, _)| {
+                        *other_node_x_coordinate != node_x_coordinate
+                    })
+                    .fold(Self::ONE, |product, (other_node_x_coordinate, _)| {
+                        product * (input - Self::from_u128(other_node_x_coordinate as u128))
+                    })
+                    * *node_y_coordinate
+                    * denominator;
+                eval += basis_poly_eval;
+            }
+
+            output.push(eval);
+        }
+
+        output
+    }
 }
 
 pub fn field_element_iter<FE: CodecFieldElement>() -> impl Iterator<Item = FE> {
@@ -791,5 +854,41 @@ mod tests {
     #[wasm_bindgen_test(unsupported = test)]
     fn lagrange_basis_polynomial_field_2_128() {
         lagrange_basis_polynomial_test::<Field2_128>();
+    }
+
+    fn extend_x_2<FE: LagrangePolynomialFieldElement>() {
+        let output = FE::extend(
+            // x^2 evaluated at 0, 1, 2 => 0, 1, 4
+            &[FE::ZERO, FE::ONE, FE::from_u128(4)],
+            6,
+        );
+
+        assert_eq!(
+            output,
+            // x^2 evaluated at 0..6 = > 0, 1, 4, 9, 16, 25
+            vec![
+                FE::ZERO,
+                FE::ONE,
+                FE::from_u128(4),
+                FE::from_u128(9),
+                FE::from_u128(16),
+                FE::from_u128(25),
+            ]
+        );
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn extend_x_2_p128() {
+        extend_x_2::<FieldP128>();
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn extend_x_2_p256() {
+        extend_x_2::<FieldP256>();
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn extend_x_2_p521() {
+        extend_x_2::<FieldP521>();
     }
 }

--- a/src/ligero/merkle.rs
+++ b/src/ligero/merkle.rs
@@ -2,7 +2,7 @@
 //!
 //! [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-4.1
 
-use crate::{Codec, ligero::committer::LigeroCommitment};
+use crate::{Codec, ligero::LigeroCommitment};
 use anyhow::anyhow;
 use sha2::{Digest, Sha256};
 use std::fmt::Debug;

--- a/src/ligero/mod.rs
+++ b/src/ligero/mod.rs
@@ -2,12 +2,13 @@
 //!
 //! [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-4
 
-use crate::fields::LagrangePolynomialFieldElement;
+use anyhow::Context;
+use merkle::Node;
 use serde::Deserialize;
 
-pub mod committer;
 pub mod merkle;
 pub mod prover;
+pub mod tableau;
 pub mod verifier;
 
 /// Common parameters for the Ligero proof system. Described in [Section 4.2][1].
@@ -30,242 +31,42 @@ pub struct LigeroParameters {
     pub num_columns: usize,
 }
 
-/// Describes the layout of the tableau. The verifier does not actually have the entire tableau, but
-/// needs the layout to locate corresponding values in the blinds it generates or the columns
-/// revealed by the prover.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TableauLayout<'a> {
-    parameters: &'a LigeroParameters,
-    num_witnesses: usize,
-    num_quadratic_constraints: usize,
-}
-
-impl<'a> TableauLayout<'a> {
-    pub fn new(
-        parameters: &'a LigeroParameters,
-        num_witnesses: usize,
-        num_quadratic_constraints: usize,
-    ) -> Self {
-        Self {
-            parameters,
-            num_witnesses,
-            num_quadratic_constraints,
-        }
-    }
-
-    /// Index of the low degree test row.
-    pub const fn low_degree_test_row() -> usize {
-        0
-    }
-
-    /// Index of the dot proof row, aka linear test row.
-    pub const fn dot_proof_row() -> usize {
-        1
-    }
-
-    /// Index of the quadratic test row.
-    pub const fn quadratic_test_row() -> usize {
-        2
-    }
-
-    /// The size of a block, in terms of number of field elements. Also `BLOCK`. The specification
-    /// describes this quantity as the "size of each row", but that would be `NCOL` or
-    /// `num_columns`.
-    pub fn block_size(&self) -> usize {
-        self.parameters.block_size
-    }
-
-    /// The total size of a tableau row. Also `NCOL`.
-    pub fn num_columns(&self) -> usize {
-        self.parameters.num_columns
-    }
-
-    /// The number of columns of the tableau that the Verifier requests to be revealed by the
-    /// Prover. Also `NREQ`.
-    pub fn num_requested_columns(&self) -> usize {
-        self.parameters.nreq
-    }
-
-    /// `DBLOCK = 2 * BLOCK - 1`
-    pub fn dblock(&self) -> usize {
-        self.parameters.block_size * 2 - 1
-    }
-
-    /// The number of witness values included in each row. Also `WR`.
-    pub fn witnesses_per_row(&self) -> usize {
-        self.parameters.witnesses_per_row
-    }
-
-    /// The number of quadratic constraints written in each row. Also `QR`.
-    pub fn quadratic_constraints_per_row(&self) -> usize {
-        self.parameters.quadratic_constraints_per_row
-    }
-
-    /// Index of the first row of the tableau containing witnesses, used in the linear constraint
-    /// test.
-    pub fn first_witness_row(&self) -> usize {
-        // One row each for low degree, linear and quadratic tests.
-        3
-    }
-
-    /// Index of the first row of the tableau containing quadratic constraints on the witnesses.
-    pub fn first_quadratic_constraint_row(&self) -> usize {
-        self.first_witness_row() + self.num_linear_constraint_rows()
-    }
-
-    /// The number of triples of tableau rows needed to represent the quadratic constraints
-    pub fn num_quadratic_triples(&self) -> usize {
-        self.num_quadratic_constraints
-            .div_ceil(self.parameters.quadratic_constraints_per_row)
-    }
-
-    /// The number of tableau rows needed to represent the quadratic constraints.
-    pub fn num_quadratic_rows(&self) -> usize {
-        3 * self.num_quadratic_triples()
-    }
-
-    /// The number of tableau rows needed to represent linear constraints on the witnesses.
-    pub fn num_linear_constraint_rows(&self) -> usize {
-        self.num_witnesses
-            .div_ceil(self.parameters.witnesses_per_row)
-    }
-
-    /// The total number of rows in the tableau for witness constraints.
-    pub fn num_constraint_rows(&self) -> usize {
-        self.num_linear_constraint_rows() + self.num_quadratic_rows()
-    }
-
-    /// The total number of rows in the tableau.
-    pub fn num_rows(&self) -> usize {
-        self.first_witness_row() + self.num_linear_constraint_rows() + self.num_quadratic_rows()
-    }
-
-    /// Gather the tableau elements at the provided indices from source, in the order of the
-    /// indices. As specified in [2.1][1].
-    ///
-    /// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-2.1
-    pub fn gather_iter<FE: LagrangePolynomialFieldElement>(
-        &self,
-        source: &[FE],
-        indices: &[usize],
-    ) -> impl Iterator<Item = FE> {
-        // offset by dblock so that we yield tableau elements, not witnesses.
-        indices.iter().map(|index| source[*index + self.dblock()])
-    }
-
-    /// Gather the tableau elements at the provided indices from source, in the order of the indices. As
-    /// specified in [2.1][1].
-    ///
-    /// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-2.1
-    pub fn gather<FE: LagrangePolynomialFieldElement>(
-        &self,
-        source: &[FE],
-        indices: &[usize],
-    ) -> Vec<FE> {
-        self.gather_iter(source, indices).collect()
-    }
-}
-
-/// The extend method, as defined in [2.2.1][1]. We interpolate a polynomial of degree at most
-/// `nodes.len() - 1` from the provided evaluations at points `[0..nodes.len())` and then evaluate
-/// that polynomial at `[0, evaluations)`.
+/// A commitment to a witness vector, as specified in [1]. Concretely, this is the root of a Merkle
+/// tree of SHA-256 hashes.
 ///
-/// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-2.2.1
-pub fn extend<FE: LagrangePolynomialFieldElement>(nodes: &[FE], evaluations: usize) -> Vec<FE> {
-    // For now we use the relatively straightforward method of computing Lagrange basis polynomials
-    // for each provided point.
-    //
-    // https://en.wikipedia.org/wiki/Lagrange_polynomial#Definition
-    let mut output = Vec::with_capacity(evaluations);
-    let mut denominators = vec![None; nodes.len()];
+/// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-4.3
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LigeroCommitment([u8; 32]);
 
-    for input in (0..evaluations).map(|e| FE::from_u128(e as u128)) {
-        let mut eval = FE::ZERO;
-
-        // Evaluate each basis polynomial
-        for (node_x_coordinate, node_y_coordinate) in nodes.iter().enumerate() {
-            // Compute and cache denominators
-            let denominator = match denominators[node_x_coordinate] {
-                Some(denominator) => denominator,
-                None => {
-                    let denominator = nodes
-                        .iter()
-                        .enumerate()
-                        .filter(|(other_node_x_coordinate, _)| {
-                            *other_node_x_coordinate != node_x_coordinate
-                        })
-                        .fold(FE::ONE, |product, (other_node_x_coordinate, _)| {
-                            product
-                                * (FE::from_u128(node_x_coordinate as u128)
-                                    - FE::from_u128(other_node_x_coordinate as u128))
-                        })
-                        .mul_inv();
-                    denominators[node_x_coordinate] = Some(denominator);
-                    denominator
-                }
-            };
-
-            // Compute each term of the basis polynomial
-            let basis_poly_eval = nodes
-                .iter()
-                .enumerate()
-                .filter(|(other_node_x_coordinate, _)| {
-                    *other_node_x_coordinate != node_x_coordinate
-                })
-                .fold(FE::ONE, |product, (other_node_x_coordinate, _)| {
-                    product * (input - FE::from_u128(other_node_x_coordinate as u128))
-                })
-                * *node_y_coordinate
-                * denominator;
-            eval += basis_poly_eval;
-        }
-
-        output.push(eval);
+impl TryFrom<&[u8]> for LigeroCommitment {
+    type Error = anyhow::Error;
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let commitment: [u8; 32] = value
+            .try_into()
+            .context("byte slice wrong size for commitment")?;
+        Ok(LigeroCommitment(commitment))
     }
-
-    output
 }
 
-#[cfg(test)]
-mod tests {
-    use wasm_bindgen_test::wasm_bindgen_test;
+impl From<Node> for LigeroCommitment {
+    fn from(value: Node) -> Self {
+        Self(<[u8; 32]>::from(value))
+    }
+}
 
-    use super::*;
-    use crate::fields::{fieldp128::FieldP128, fieldp256::FieldP256, fieldp521::FieldP521};
-
-    fn extend_x_2<FE: LagrangePolynomialFieldElement>() {
-        let output = extend(
-            // x^2 evaluated at 0, 1, 2 => 0, 1, 4
-            &[FE::ZERO, FE::ONE, FE::from_u128(4)],
-            6,
-        );
-
-        assert_eq!(
-            output,
-            // x^2 evaluated at 0..6 = > 0, 1, 4, 9, 16, 25
-            vec![
-                FE::ZERO,
-                FE::ONE,
-                FE::from_u128(4),
-                FE::from_u128(9),
-                FE::from_u128(16),
-                FE::from_u128(25),
-            ]
-        );
+impl LigeroCommitment {
+    /// The commitment as a slice of bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
     }
 
-    #[wasm_bindgen_test(unsupported = test)]
-    fn extend_x_2_p128() {
-        extend_x_2::<FieldP128>();
+    pub fn into_bytes(&self) -> [u8; 32] {
+        self.0
     }
 
-    #[wasm_bindgen_test(unsupported = test)]
-    fn extend_x_2_p256() {
-        extend_x_2::<FieldP256>();
-    }
-
-    #[wasm_bindgen_test(unsupported = test)]
-    fn extend_x_2_p521() {
-        extend_x_2::<FieldP521>();
+    /// A fake but well-formed commitment for tests.
+    #[cfg(test)]
+    pub fn test_commitment() -> Self {
+        Self::try_from([1u8; 32].as_slice()).unwrap()
     }
 }

--- a/src/ligero/verifier.rs
+++ b/src/ligero/verifier.rs
@@ -6,11 +6,10 @@ use crate::{
     constraints::proof_constraints::{LinearConstraints, QuadraticConstraint},
     fields::{CodecFieldElement, LagrangePolynomialFieldElement},
     ligero::{
-        TableauLayout,
-        committer::LigeroCommitment,
-        extend,
+        LigeroCommitment,
         merkle::{MerkleTree, Node},
         prover::{LigeroProof, inner_product_vector},
+        tableau::TableauLayout,
     },
     transcript::Transcript,
 };
@@ -68,7 +67,7 @@ pub fn ligero_verify<FE: CodecFieldElement + LagrangePolynomialFieldElement>(
     }
 
     let proof_low_degree_test_row = layout.gather(
-        &extend(&proof.low_degree_test_proof, layout.num_columns()),
+        &FE::extend(&proof.low_degree_test_proof, layout.num_columns()),
         &requested_column_indices,
     );
 
@@ -115,7 +114,7 @@ pub fn ligero_verify<FE: CodecFieldElement + LagrangePolynomialFieldElement>(
         inner_product_vector_extended.resize(layout.num_requested_columns(), FE::ZERO);
         inner_product_vector_extended.extend(products);
 
-        let extended = extend(&inner_product_vector_extended, layout.num_columns());
+        let extended = FE::extend(&inner_product_vector_extended, layout.num_columns());
         for ((want_dot_row_element, inner_product_element), tableau_element) in want_dot_row
             .iter_mut()
             .zip(layout.gather_iter(&extended, &requested_column_indices))
@@ -126,7 +125,7 @@ pub fn ligero_verify<FE: CodecFieldElement + LagrangePolynomialFieldElement>(
     }
 
     let proof_dot_row = layout.gather(
-        &extend(&proof.dot_proof, layout.num_columns()),
+        &FE::extend(&proof.dot_proof, layout.num_columns()),
         &requested_column_indices,
     );
 
@@ -159,7 +158,7 @@ pub fn ligero_verify<FE: CodecFieldElement + LagrangePolynomialFieldElement>(
     }
 
     let proof_quadratic_test_row = layout.gather(
-        &extend(&proof.quadratic_proof(layout), layout.num_columns()),
+        &FE::extend(&proof.quadratic_proof(layout), layout.num_columns()),
         &requested_column_indices,
     );
 
@@ -202,7 +201,7 @@ mod tests {
         constraints::proof_constraints::quadratic_constraints,
         decode_test_vector,
         fields::{FieldElement, fieldp128::FieldP128},
-        ligero::TableauLayout,
+        ligero::tableau::TableauLayout,
         sumcheck::prover::SumcheckProof,
         test_vector::CircuitTestVector,
         transcript::Transcript,

--- a/src/sumcheck/prover.rs
+++ b/src/sumcheck/prover.rs
@@ -3,7 +3,7 @@
 use crate::{
     circuit::{Circuit, CircuitLayer, Evaluation},
     fields::CodecFieldElement,
-    ligero::committer::LigeroCommitment,
+    ligero::LigeroCommitment,
     sumcheck::{
         Polynomial,
         bind::{ElementwiseSum, SumcheckArray},

--- a/src/test_vector.rs
+++ b/src/test_vector.rs
@@ -5,7 +5,7 @@ use crate::{
     circuit::Circuit,
     constraints::proof_constraints::QuadraticConstraint,
     fields::{CodecFieldElement, FieldElement},
-    ligero::{LigeroParameters, committer::LigeroCommitment},
+    ligero::{LigeroCommitment, LigeroParameters},
 };
 use serde::Deserialize;
 use std::io::Cursor;

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -6,8 +6,7 @@
 use std::fmt::Debug;
 
 use crate::{
-    circuit::Circuit, fields::CodecFieldElement, ligero::committer::LigeroCommitment,
-    sumcheck::Polynomial,
+    circuit::Circuit, fields::CodecFieldElement, ligero::LigeroCommitment, sumcheck::Polynomial,
 };
 use aes::{
     Aes256,

--- a/src/zk_one_circuit/prover.rs
+++ b/src/zk_one_circuit/prover.rs
@@ -5,9 +5,9 @@ use crate::{
     },
     fields::{CodecFieldElement, LagrangePolynomialFieldElement},
     ligero::{
-        LigeroParameters,
-        committer::{LigeroCommitment, Tableau},
-        prover::{LigeroProof, LigeroProver},
+        LigeroCommitment, LigeroParameters,
+        prover::{LigeroProof, ligero_prove},
+        tableau::Tableau,
     },
     sumcheck::prover::{SumcheckProof, SumcheckProver},
     transcript::Transcript,
@@ -85,7 +85,7 @@ impl<'a> Prover<'a> {
         )?;
 
         // Generate Ligero proof.
-        let ligero_proof = LigeroProver::ligero_prove(
+        let ligero_proof = ligero_prove(
             &mut transcript,
             &tableau,
             &merkle_tree,

--- a/src/zk_one_circuit/verifier.rs
+++ b/src/zk_one_circuit/verifier.rs
@@ -4,7 +4,7 @@ use crate::{
         LinearConstraints, QuadraticConstraint, quadratic_constraints,
     },
     fields::{CodecFieldElement, LagrangePolynomialFieldElement},
-    ligero::{LigeroParameters, TableauLayout, verifier::ligero_verify},
+    ligero::{LigeroParameters, tableau::TableauLayout, verifier::ligero_verify},
     transcript::Transcript,
     witness::WitnessLayout,
     zk_one_circuit::prover::Proof,


### PR DESCRIPTION
- Reduce `LigeroProver::ligero_prove` to just `ligero_prove` (this
  causes a large diff because lots of code that doesn't change moves
  left by one indent)
- Rename mod `ligero::committer` to `tableau`
- move `TableauLayout` from `ligero` to `ligero::Tableau`
- move `LigeroCommitment` from `ligero::tableau` to `ligero`
- move `ligero::extend` to trait method on
  `LagrangePolynomialFieldElement`.

No actual logic changes.