### PR TITLE
Implement serialization of proofs

### DIFF
--- a/src/zk_one_circuit.rs
+++ b/src/zk_one_circuit.rs
@@ -29,6 +29,6 @@ mod tests {
         let proof = prover.prove(session_id, &all_inputs).unwrap();
 
         let verifier = Verifier::new(&circuit, ligero_parameters);
-        verifier.verify(session_id, public_inputs, &proof).unwrap();
+        verifier.verify(public_inputs, &proof).unwrap();
     }
 }

--- a/src/zk_one_circuit/verifier.rs
+++ b/src/zk_one_circuit/verifier.rs
@@ -32,12 +32,7 @@ impl<'a> Verifier<'a> {
     }
 
     /// Verify a Longfellow ZK proof.
-    pub fn verify<FE>(
-        &self,
-        session_id: &[u8],
-        statement: &[FE],
-        proof: &Proof<FE>,
-    ) -> Result<(), anyhow::Error>
+    pub fn verify<FE>(&self, statement: &[FE], proof: &Proof<FE>) -> Result<(), anyhow::Error>
     where
         FE: CodecFieldElement + LagrangePolynomialFieldElement,
     {
@@ -54,7 +49,7 @@ impl<'a> Verifier<'a> {
         );
 
         // Start of Fiat-Shamir transcript.
-        let mut transcript = Transcript::new(session_id).unwrap();
+        let mut transcript = Transcript::new(proof.oracle()).unwrap();
 
         // Run sumcheck verifier, and produce deferred linear constraints.
         let linear_constraints = LinearConstraints::from_proof(


### PR DESCRIPTION
This adds `encode()` and `decode()` methods to the Longfellow one-circuit `Proof` struct. See https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-7.5 for the struct definition.