### PR TITLE
Use typestate to make `Transcript` easier to use

### DIFF
--- a/src/zk_one_circuit.rs
+++ b/src/zk_one_circuit.rs
@@ -27,7 +27,6 @@ mod tests {
 
         let prover = Prover::new(&circuit, ligero_parameters.clone());
         let proof = prover.prove(session_id, &all_inputs).unwrap();
-
         let verifier = Verifier::new(&circuit, ligero_parameters);
         verifier.verify(public_inputs, &proof).unwrap();
     }

--- a/src/zk_one_circuit/verifier.rs
+++ b/src/zk_one_circuit/verifier.rs
@@ -49,13 +49,13 @@ impl<'a> Verifier<'a> {
         );
 
         // Start of Fiat-Shamir transcript.
-        let mut transcript = Transcript::new(proof.oracle()).unwrap();
+        let transcript = Transcript::new(proof.oracle()).unwrap();
 
         // Run sumcheck verifier, and produce deferred linear constraints.
-        let linear_constraints = LinearConstraints::from_proof(
+        let (linear_constraints, constraints_transcript) = LinearConstraints::from_proof(
             self.circuit,
             &inputs,
-            &mut transcript,
+            transcript,
             &proof.ligero_commitment(),
             proof.sumcheck_proof(),
         )?;
@@ -64,7 +64,7 @@ impl<'a> Verifier<'a> {
         ligero_verify(
             proof.ligero_commitment(),
             proof.ligero_proof(),
-            &mut transcript,
+            constraints_transcript,
             &linear_constraints,
             &self.quadratic_constraints,
             &tableau_layout,


### PR DESCRIPTION
The handling of the FSPRF transcript in Longfellow is a little tricky. The verifier has to:

- initialize a transcript
- use it to generate constraints from the Sumcheck proof
- use it to verify the Ligero proof

The prover has to:

- initialize a transcript
- use it to generate the Sumcheck proof
- initialize another transcript
- use that transcript to generate constraints from the proof
- use either transcript to generate the Ligero proof

It's all too easy to use the wrong transcript, get your FSPRF out of sync and compute the wrong results.

This commit introduces wrapper structs `SumcheckTranscript`, `ConstraintsTranscript` and `LigeroTranscript` so that we can represent the state transitions in the verifier and prover by changing the type of the transcript.

Each of `SumcheckProver::prove`, `ProofConstraints::from_proof`, `ligero_verify` and `ligero_prove` now return the transcripts they used so that they can either be used in a subsequent protocol step or examined by tests.

The verifier will initiate a `Transcript`, then will call `ProofConstraints::from_proof` to exchange it for a `ConstraintsTranscript` which can then be passed to `ligero_verify`.

The prover will initiate a `Transcript`, then will pass a reference to that transcript to `SumcheckProver::prove`, which will clone the transcript and convert it to a `SumcheckTranscript`. The prover will then pass the initial transcript (since only an immutable reference was passed to `SumcheckProver`) to `ProofConstraints::from_proof`, which will yield the `ConstraintsTranscript` that the prover must use with `ligero_prove`.

`ligero_prove` could just as easily take a `SumcheckTranscript`, but we choose to instead use `ConstraintsTranscript` so that there is symmetry between the prover and verifier side.

We also put some useful methods on `LigeroTranscript` to unify challenge generation and transcript writes across the prover and verifier.