### PR TITLE
Add functions to load specific test vectors

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -519,12 +519,11 @@ pub(crate) mod tests {
     use crate::{
         Codec, Size,
         circuit::{Circuit, CircuitLayer, Evaluation, Quad},
-        decode_test_vector,
         fields::{
             CodecFieldElement, FieldElement, FieldId, SerializedFieldElement, fieldp128::FieldP128,
             fieldp256::FieldP256,
         },
-        test_vector::CircuitTestVector,
+        test_vector::{CircuitTestVector, load_mac, load_rfc},
     };
     use std::{collections::HashSet, io::Cursor};
     use wasm_bindgen_test::wasm_bindgen_test;
@@ -619,25 +618,17 @@ pub(crate) mod tests {
 
     #[wasm_bindgen_test(unsupported = test)]
     fn roundtrip_circuit_longfellow_rfc_1() {
-        roundtrip_circuit_test_vector::<FieldP128>(decode_test_vector!(
-            "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
-            proofs,
-        ));
+        roundtrip_circuit_test_vector::<FieldP128>(load_rfc());
     }
 
     #[wasm_bindgen_test(unsupported = test)]
     fn roundtrip_circuit_test_vector_mac() {
-        roundtrip_circuit_test_vector::<FieldP256>(decode_test_vector!(
-            "longfellow-mac-circuit-902a955fbb22323123aac5b69bdf3442e6ea6f80-1",
-        ));
+        roundtrip_circuit_test_vector::<FieldP256>(load_mac());
     }
 
     #[wasm_bindgen_test(unsupported = test)]
     fn evaluate_circuit_longfellow_rfc_1_true() {
-        let (test_vector, circuit) = decode_test_vector!(
-            "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
-            proofs,
-        );
+        let (test_vector, circuit) = load_rfc();
 
         let evaluation: Evaluation<FieldP128> =
             circuit.evaluate(&test_vector.valid_inputs()).unwrap();
@@ -658,10 +649,7 @@ pub(crate) mod tests {
 
     #[wasm_bindgen_test(unsupported = test)]
     fn evaluate_circuit_longfellow_rfc_1_false() {
-        let (test_vector, circuit) = decode_test_vector!(
-            "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
-            proofs,
-        );
+        let (test_vector, circuit) = load_rfc();
 
         // Evaluate with other values. At least one output element should be nonzero.
         assert!(

--- a/src/constraints/proof_constraints.rs
+++ b/src/constraints/proof_constraints.rs
@@ -340,19 +340,15 @@ mod tests {
     use super::*;
     use crate::{
         circuit::Evaluation,
-        decode_test_vector,
         fields::{CodecFieldElement, FieldElement, fieldp128::FieldP128},
         sumcheck::prover::SumcheckProver,
-        test_vector::CircuitTestVector,
+        test_vector::load_rfc,
         witness::Witness,
     };
 
     #[wasm_bindgen_test(unsupported = test)]
     fn self_consistent() {
-        let (test_vector, circuit) = decode_test_vector!(
-            "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
-            proofs,
-        );
+        let (test_vector, circuit) = load_rfc();
 
         let evaluation: Evaluation<FieldP128> =
             circuit.evaluate(&test_vector.valid_inputs()).unwrap();
@@ -434,10 +430,7 @@ mod tests {
 
     #[wasm_bindgen_test(unsupported = test)]
     fn longfellow_rfc_1_87474f308020535e57a778a82394a14106f8be5b() {
-        let (test_vector, circuit) = decode_test_vector!(
-            "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
-            proofs,
-        );
+        let (test_vector, circuit) = load_rfc();
 
         let test_vector_constraints = test_vector.constraints.as_ref().unwrap();
 

--- a/src/ligero/prover.rs
+++ b/src/ligero/prover.rs
@@ -399,11 +399,10 @@ mod tests {
     use crate::{
         circuit::Evaluation,
         constraints::proof_constraints::quadratic_constraints,
-        decode_test_vector,
         fields::fieldp128::FieldP128,
         ligero::LigeroCommitment,
         sumcheck,
-        test_vector::CircuitTestVector,
+        test_vector::load_rfc,
         transcript::Transcript,
         witness::{Witness, WitnessLayout},
     };
@@ -412,10 +411,7 @@ mod tests {
 
     #[wasm_bindgen_test(unsupported = test)]
     fn longfellow_rfc_1_87474f308020535e57a778a82394a14106f8be5b() {
-        let (test_vector, circuit) = decode_test_vector!(
-            "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
-            proofs,
-        );
+        let (test_vector, circuit) = load_rfc();
         let ligero_parameters = test_vector.ligero_parameters();
 
         let evaluation: Evaluation<FieldP128> =
@@ -488,10 +484,7 @@ mod tests {
 
     #[wasm_bindgen_test(unsupported = test)]
     fn ligero_proof_codec_roundtrip() {
-        let (test_vector, circuit) = decode_test_vector!(
-            "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
-            proofs,
-        );
+        let (test_vector, circuit) = load_rfc();
         let ligero_parameters = test_vector.ligero_parameters();
 
         let witness_layout = WitnessLayout::from_circuit(&circuit);

--- a/src/ligero/tableau.rs
+++ b/src/ligero/tableau.rs
@@ -378,20 +378,16 @@ mod tests {
     use crate::{
         circuit::Evaluation,
         constraints::proof_constraints::quadratic_constraints,
-        decode_test_vector,
         fields::fieldp128::FieldP128,
         ligero::LigeroCommitment,
-        test_vector::CircuitTestVector,
+        test_vector::load_rfc,
         witness::{Witness, WitnessLayout},
     };
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[wasm_bindgen_test(unsupported = test)]
     fn longfellow_rfc_1_87474f308020535e57a778a82394a14106f8be5b() {
-        let (test_vector, circuit) = decode_test_vector!(
-            "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
-            proofs,
-        );
+        let (test_vector, circuit) = load_rfc();
 
         let evaluation: Evaluation<FieldP128> =
             circuit.evaluate(&test_vector.valid_inputs()).unwrap();

--- a/src/ligero/verifier.rs
+++ b/src/ligero/verifier.rs
@@ -199,11 +199,10 @@ mod tests {
     use super::*;
     use crate::{
         constraints::proof_constraints::quadratic_constraints,
-        decode_test_vector,
         fields::{FieldElement, fieldp128::FieldP128},
         ligero::tableau::TableauLayout,
         sumcheck::prover::SumcheckProof,
-        test_vector::CircuitTestVector,
+        test_vector::load_rfc,
         transcript::Transcript,
         witness::WitnessLayout,
     };
@@ -212,10 +211,7 @@ mod tests {
 
     #[wasm_bindgen_test(unsupported = test)]
     fn longfellow_rfc_1_87474f308020535e57a778a82394a14106f8be5b() {
-        let (test_vector, circuit) = decode_test_vector!(
-            "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
-            proofs,
-        );
+        let (test_vector, circuit) = load_rfc();
         let ligero_parameters = test_vector.ligero_parameters();
 
         // hack: prepend 1 to the inputs just like Circuit::evaluate does

--- a/src/sumcheck/prover.rs
+++ b/src/sumcheck/prover.rs
@@ -348,17 +348,13 @@ mod tests {
 
     use super::*;
     use crate::{
-        Size, decode_test_vector, fields::fieldp128::FieldP128, test_vector::CircuitTestVector,
-        witness::WitnessLayout,
+        Size, fields::fieldp128::FieldP128, test_vector::load_rfc, witness::WitnessLayout,
     };
     use std::io::Cursor;
 
     #[wasm_bindgen_test(unsupported = test)]
     fn longfellow_rfc_1_87474f308020535e57a778a82394a14106f8be5b() {
-        let (test_vector, circuit) = decode_test_vector!(
-            "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
-            proofs,
-        );
+        let (test_vector, circuit) = load_rfc();
 
         assert_eq!(circuit.num_copies, Size(1));
 
@@ -407,10 +403,7 @@ mod tests {
 
     #[wasm_bindgen_test(unsupported = test)]
     fn roundtrip_encoded_proof() {
-        let (test_vector, circuit) = decode_test_vector!(
-            "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
-            proofs,
-        );
+        let (test_vector, circuit) = load_rfc();
         let test_vector_decoded = SumcheckProof::<FieldP128>::decode(
             &circuit,
             &mut Cursor::new(&test_vector.serialized_sumcheck_proof),

--- a/src/test_vector.rs
+++ b/src/test_vector.rs
@@ -79,6 +79,19 @@ macro_rules! decode_test_vector {
     };
 }
 
+/// Load the test vector for the "rfc" circuit.
+pub(crate) fn load_rfc() -> (CircuitTestVector, Circuit) {
+    decode_test_vector!(
+        "longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b",
+        proofs,
+    )
+}
+
+/// Load the test vector for the "mac" circuit.
+pub(crate) fn load_mac() -> (CircuitTestVector, Circuit) {
+    decode_test_vector!("longfellow-mac-circuit-902a955fbb22323123aac5b69bdf3442e6ea6f80-1")
+}
+
 /// JSON descriptor of a circuit test vector.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct CircuitTestVector {

--- a/src/zk_one_circuit.rs
+++ b/src/zk_one_circuit.rs
@@ -6,9 +6,8 @@ pub mod verifier;
 #[cfg(test)]
 mod tests {
     use crate::{
-        decode_test_vector,
         fields::fieldp128::FieldP128,
-        test_vector::CircuitTestVector,
+        test_vector::load_rfc,
         zk_one_circuit::{
             prover::{Proof, Prover},
             verifier::Verifier,
@@ -22,8 +21,7 @@ mod tests {
         // Here, we just load the test vector file to get the Ligero parameters,
         // and discard the proof. We generate a fresh proof, using real
         // randomness.
-        let (test_vector, circuit) =
-            decode_test_vector!("longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b");
+        let (test_vector, circuit) = load_rfc();
         let ligero_parameters = test_vector.ligero_parameters();
         let all_inputs: Vec<FieldP128> = test_vector.valid_inputs();
         let public_inputs = &all_inputs[..circuit.num_public_inputs() - 1];
@@ -39,8 +37,7 @@ mod tests {
     #[ignore = "slow test"]
     #[wasm_bindgen_test(unsupported = test)]
     fn longfellow_rfc_1_87474f308020535e57a778a82394a14106f8be5b_mutation() {
-        let (test_vector, circuit) =
-            decode_test_vector!("longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b");
+        let (test_vector, circuit) = load_rfc();
         let ligero_parameters = test_vector.ligero_parameters();
         let all_inputs: Vec<FieldP128> = test_vector.valid_inputs();
         let public_inputs = &all_inputs[..circuit.num_public_inputs() - 1];

--- a/src/zk_one_circuit/prover.rs
+++ b/src/zk_one_circuit/prover.rs
@@ -191,9 +191,8 @@ mod tests {
     use std::io::Cursor;
 
     use crate::{
-        decode_test_vector,
         fields::fieldp128::FieldP128,
-        test_vector::CircuitTestVector,
+        test_vector::load_rfc,
         zk_one_circuit::{
             prover::{Proof, Prover},
             verifier::Verifier,
@@ -203,8 +202,7 @@ mod tests {
 
     #[wasm_bindgen_test(unsupported = test)]
     fn proof_round_trip() {
-        let (test_vector, circuit) =
-            decode_test_vector!("longfellow-rfc-1-87474f308020535e57a778a82394a14106f8be5b");
+        let (test_vector, circuit) = load_rfc();
         let ligero_parameters = test_vector.ligero_parameters();
         let all_inputs: Vec<FieldP128> = test_vector.valid_inputs();
         let session_id = b"testtesttesttesttesttesttesttest";


### PR DESCRIPTION
This adds a couple functions that load specific test vector and circuit files. This isolates the `decode_test_vector!()` macro from test code, which helps with ergonomics a bit.