### PR TITLE
Refactor Ligero prover/verifier

### DIFF
--- a/src/ligero/mod.rs
+++ b/src/ligero/mod.rs
@@ -83,6 +83,25 @@ fn write_hash_of_a(transcript: &mut Transcript) -> Result<(), anyhow::Error> {
     ])
 }
 
+/// Write a Ligero proof to the transcript.
+pub fn write_proof<FE: CodecFieldElement>(
+    transcript: &mut Transcript,
+    low_degree_test_proof: &[FE],
+    dot_proof: &[FE],
+    quadratic_proof_low: &[FE],
+    quadratic_proof_high: &[FE],
+) -> Result<(), anyhow::Error> {
+    for proof in [
+        low_degree_test_proof,
+        dot_proof,
+        quadratic_proof_low,
+        quadratic_proof_high,
+    ] {
+        transcript.write_field_element_array(proof)?;
+    }
+    Ok(())
+}
+
 /// Challenges used to produce or verify a Ligero proof.
 struct LigeroChallenges<FE> {
     pub low_degree_test_blind: Vec<FE>,

--- a/src/ligero/prover.rs
+++ b/src/ligero/prover.rs
@@ -12,7 +12,7 @@ use crate::{
         LigeroChallenges,
         merkle::{InclusionProof, MerkleTree},
         tableau::{Tableau, TableauLayout},
-        write_hash_of_a,
+        write_hash_of_a, write_proof,
     },
     transcript::Transcript,
 };
@@ -138,10 +138,13 @@ pub fn ligero_prove<FE: CodecFieldElement + LagrangePolynomialFieldElement>(
     let quadratic_proof_high = &quadratic_proof[tableau.layout().block_size()..];
 
     // Write proofs to the transcript
-    transcript.write_field_element_array(&low_degree_test_proof)?;
-    transcript.write_field_element_array(&dot_proof)?;
-    transcript.write_field_element_array(quadratic_proof_low)?;
-    transcript.write_field_element_array(quadratic_proof_high)?;
+    write_proof(
+        transcript,
+        &low_degree_test_proof,
+        &dot_proof,
+        quadratic_proof_low,
+        quadratic_proof_high,
+    )?;
 
     let requested_column_indices = transcript.generate_naturals_without_replacement(
         tableau.layout().num_columns() - tableau.layout().dblock(),

--- a/src/ligero/verifier.rs
+++ b/src/ligero/verifier.rs
@@ -10,7 +10,7 @@ use crate::{
         merkle::{MerkleTree, Node},
         prover::{LigeroProof, inner_product_vector},
         tableau::TableauLayout,
-        write_hash_of_a,
+        write_hash_of_a, write_proof,
     },
     transcript::Transcript,
 };
@@ -34,10 +34,13 @@ pub fn ligero_verify<FE: CodecFieldElement + LagrangePolynomialFieldElement>(
         quadratic_constraints.len(),
     )?;
 
-    transcript.write_field_element_array(&proof.low_degree_test_proof)?;
-    transcript.write_field_element_array(&proof.dot_proof)?;
-    transcript.write_field_element_array(&proof.quadratic_proof.0)?;
-    transcript.write_field_element_array(&proof.quadratic_proof.1)?;
+    write_proof(
+        transcript,
+        &proof.low_degree_test_proof,
+        &proof.dot_proof,
+        &proof.quadratic_proof.0,
+        &proof.quadratic_proof.1,
+    )?;
 
     let requested_column_indices = transcript.generate_naturals_without_replacement(
         layout.num_columns() - layout.dblock(),


### PR DESCRIPTION
This extracts a few cleanups from #74, adding helper functions/methods to deduplicate code in the Ligero prover and verifier. I made these part of the `ligero` module instead of `transcript`, since they're specific to the Ligero protocol.