### PR TITLE
Implement ConditionallySelectable

### DIFF
--- a/src/fields/field2_128/mod.rs
+++ b/src/fields/field2_128/mod.rs
@@ -16,7 +16,7 @@ use std::{
     io::{Cursor, Read},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
-use subtle::ConstantTimeEq;
+use subtle::{ConditionallySelectable, ConstantTimeEq};
 
 /// An element of the field GF(2^128).
 ///
@@ -234,6 +234,12 @@ impl Neg for Field2_128 {
 
     fn neg(self) -> Self::Output {
         self
+    }
+}
+
+impl ConditionallySelectable for Field2_128 {
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        Self(u128::conditional_select(&a.0, &b.0, choice))
     }
 }
 

--- a/src/fields/fieldp256_2.rs
+++ b/src/fields/fieldp256_2.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use subtle::ConstantTimeEq;
+use subtle::{ConditionallySelectable, ConstantTimeEq};
 
 use crate::fields::{FieldElement, NttFieldElement, QuadraticExtension, fieldp256::FieldP256};
 
@@ -244,6 +244,12 @@ impl Neg for FieldP256_2 {
 
     fn neg(self) -> Self::Output {
         Self(-self.0)
+    }
+}
+
+impl ConditionallySelectable for FieldP256_2 {
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        Self(QuadraticExtension::conditional_select(&a.0, &b.0, choice))
     }
 }
 

--- a/src/fields/quadratic_extension.rs
+++ b/src/fields/quadratic_extension.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use subtle::ConstantTimeEq;
+use subtle::{ConditionallySelectable, ConstantTimeEq};
 
 use crate::fields::FieldElement;
 
@@ -239,6 +239,15 @@ impl<B: Neg<Output = B>> Neg for QuadraticExtension<B> {
         Self {
             real: -self.real,
             imag: -self.imag,
+        }
+    }
+}
+
+impl<B: ConditionallySelectable> ConditionallySelectable for QuadraticExtension<B> {
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        Self {
+            real: B::conditional_select(&a.real, &b.real, choice),
+            imag: B::conditional_select(&a.imag, &b.imag, choice),
         }
     }
 }


### PR DESCRIPTION
This adds a `ConditionallySelectable` trait bound to `FieldElement` and adds matching trait implementations, using either fiat-crypto generated methods or dispatching to provided implementations on primitive types.