### PR TITLE
Add benchmarks

### DIFF
--- a/benches/extend.rs
+++ b/benches/extend.rs
@@ -36,6 +36,18 @@ fn benchmark_extend<FE: LagrangePolynomialFieldElement>(g: &mut BenchmarkGroup<W
             sample_size: 10,
             measurement_time: Duration::from_secs(30),
         },
+        Parameters {
+            input_size: 981,
+            output_size: 2945,
+            sample_size: 10,
+            measurement_time: Duration::from_secs(30),
+        },
+        Parameters {
+            input_size: 1363,
+            output_size: 4096,
+            sample_size: 10,
+            measurement_time: Duration::from_secs(30),
+        },
     ] {
         g.sample_size(sample_size);
         g.measurement_time(measurement_time);


### PR DESCRIPTION
This adds benchmarks for `extend()` using $GF(2^{128})$, and adds benchmarks using realistic parameter sizes (taken from some mdoc_zk circuits).