### PR TITLE
Initial mockup of mdoc_zk JS API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +57,17 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "autocfg"
@@ -99,6 +119,19 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -161,6 +194,12 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -343,6 +382,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -393,10 +456,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
-name = "log"
-version = "0.4.28"
+name = "libm"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -412,6 +481,15 @@ checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
 dependencies = [
  "cc",
  "walkdir",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -440,6 +518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -765,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -777,24 +856,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.54"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -805,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -815,34 +880,42 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.54"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e381134e148c1062f965a42ed1f5ee933eef2927c3f70d1812158f711d39865"
+checksum = "25e90e66d265d3a1efc0e72a54809ab90b9c0c515915c67cdf658689d2c22c6c"
 dependencies = [
+ "async-trait",
+ "cast",
  "js-sys",
+ "libm",
  "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
@@ -850,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.54"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b673bca3298fe582aeef8352330ecbad91849f85090805582400850f8270a2e8"
+checksum = "7150335716dce6028bead2b848e72f47b45e7b9422f64cccdc23bedca89affc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -861,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.81"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -901,10 +974,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -948,6 +1074,9 @@ dependencies = [
  "aes",
  "anyhow",
  "byteorder",
+ "chrono",
+ "ciborium",
+ "ciborium-ll",
  "criterion",
  "crypto-common",
  "educe",
@@ -961,6 +1090,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "subtle",
+ "wasm-bindgen",
  "wasm-bindgen-test",
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2024"
 aes = "0.8.4"
 anyhow = "1"
 byteorder = "1.5.0"
+chrono = "0.4.42"
+ciborium = "0.2.2"
+ciborium-ll = "0.2.2"
 crypto-common = "0.1.6"
 educe = { version = "0.6.0", features = ["Debug", "Clone", "Copy", "Hash", "Default"] }
 getrandom = { version = "0.3.3", features = ["wasm_js"] }
@@ -18,6 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 sha2 = "0.10.9"
 subtle = "2.6.1"
+wasm-bindgen = "0.2.106"
 zstd = "0.13.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
@@ -48,3 +52,6 @@ harness = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+lto = true

--- a/src/js_api.rs
+++ b/src/js_api.rs
@@ -1,0 +1,89 @@
+#![allow(unused)]
+
+use crate::{
+    ligero::LigeroParameters,
+    mdoc_zk::{self, CircuitVersion, EcdsaP256Signature, MdocZkProver},
+};
+use chrono::DateTime;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+/// Creates a proof of possession of a credential and a device binding signature.
+///
+/// # Arguments
+///
+/// * `circuit_version`: The version of the mdoc_zk circuit interface to use.
+/// * `circuit`: The compressed circuit file. This must match the circuit version and number of
+///   disclosed claims.
+/// * `device_response`: The mDoc's DeviceResponse, as CBOR data.
+/// * `namespace`: The namespace of the claims.
+/// * `requested_claims`: The names of the claims to be disclosed.
+/// * `session_transcript`: The `SessionTranscript`, as CBOR data.
+/// * `device_authentication_signature_r`: The first component of the device bound key's signature
+///   of the `DeviceAuthenticationData`.
+/// * `device_authentication_signature_s`: The second component of the device bound key's signature
+///   of the `DeviceAuthenticationData`.
+/// * `time`: The current time, agreed upon by the prover and verifier.
+#[wasm_bindgen]
+#[allow(clippy::too_many_arguments, clippy::boxed_local)]
+pub fn prove(
+    circuit_version: CircuitVersion,
+    circuit: &[u8],
+    device_response: &[u8],
+    namespace: &str,
+    requested_claims: Box<[String]>,
+    session_transcript: &[u8],
+    device_authentication_signature_r: &[u8],
+    device_authentication_signature_s: &[u8],
+    time: &str,
+) -> Result<Box<[u8]>, String> {
+    let r = device_authentication_signature_r
+        .try_into()
+        .map_err(|_| "r must be 32 bytes long".to_owned())?;
+    let s = device_authentication_signature_s
+        .try_into()
+        .map_err(|_| "s must be 32 bytes long".to_owned())?;
+    let device_authentication_signature =
+        EcdsaP256Signature::new(r, s).map_err(|e| e.to_string())?;
+
+    let requested_claims = requested_claims
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+
+    let time = DateTime::parse_from_rfc3339(time)
+        .map_err(|e| format!("invalid RFC 3339 time: {e}"))?
+        .to_utc();
+
+    let prover = MdocZkProver::new(
+        circuit,
+        circuit_version,
+        requested_claims.len(),
+        LigeroParameters {
+            nreq: todo!(),
+            witnesses_per_row: todo!(),
+            quadratic_constraints_per_row: todo!(),
+            block_size: todo!(),
+            num_columns: todo!(),
+        },
+        LigeroParameters {
+            nreq: todo!(),
+            witnesses_per_row: todo!(),
+            quadratic_constraints_per_row: todo!(),
+            block_size: todo!(),
+            num_columns: todo!(),
+        },
+    )
+    .map_err(|e| e.to_string())?;
+
+    prover
+        .prove(
+            device_response,
+            namespace,
+            &requested_claims,
+            session_transcript,
+            device_authentication_signature,
+            time,
+        )
+        .map(|proof| proof.into())
+        .map_err(|e| e.to_string())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@ use std::{fmt::Display, io::Cursor};
 pub mod circuit;
 pub mod constraints;
 pub mod fields;
+pub mod js_api;
 pub mod ligero;
+pub mod mdoc_zk;
 pub mod sumcheck;
 #[cfg(test)]
 pub mod test_vector;

--- a/src/mdoc_zk.rs
+++ b/src/mdoc_zk.rs
@@ -1,0 +1,71 @@
+#![allow(unused)]
+
+use crate::{
+    circuit::Circuit, fields::fieldp256_scalar::FieldP256Scalar, ligero::LigeroParameters,
+};
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use wasm_bindgen::prelude::wasm_bindgen;
+
+/// An ECDSA signature, using the P-256 curve.
+pub struct EcdsaP256Signature {
+    r: FieldP256Scalar,
+    s: FieldP256Scalar,
+}
+
+impl EcdsaP256Signature {
+    /// Constructs a signature from two encoded scalars, r and s.
+    pub fn new(r: [u8; 32], s: [u8; 32]) -> Result<Self, anyhow::Error> {
+        let r = FieldP256Scalar::try_from(&r).context("invalid scalar r")?;
+        let s = FieldP256Scalar::try_from(&s).context("invalid scalar s")?;
+        Ok(Self { r, s })
+    }
+}
+
+/// Versions of the mdoc_zk circuit interface.
+#[wasm_bindgen]
+#[repr(usize)]
+pub enum CircuitVersion {
+    V6 = 6,
+}
+
+/// Zero-knowledge prover for mdoc credential presentations.
+pub struct MdocZkProver {
+    circuit_version: CircuitVersion,
+    num_attributes: usize,
+    signature_circuit: Circuit,
+    hash_circuit: Circuit,
+    signature_ligero_parameters: LigeroParameters,
+    hash_ligero_parameters: LigeroParameters,
+}
+
+impl MdocZkProver {
+    /// Construct a prover using the given circuit file and metadata.
+    pub fn new(
+        circuit: &[u8],
+        circuit_version: CircuitVersion,
+        num_attributes: usize,
+        signature_ligero_parameters: LigeroParameters,
+        hash_ligero_parameters: LigeroParameters,
+    ) -> Result<Self, anyhow::Error> {
+        todo!()
+    }
+
+    /// Create a proof of possession of a credential and a device binding signature.
+    pub fn prove(
+        &self,
+        device_response: &[u8],
+        namespace: &str,
+        requested_claims: &[&str],
+        session_transcript: &[u8],
+        device_authentication_signature: EcdsaP256Signature,
+        time: DateTime<Utc>,
+    ) -> Result<Vec<u8>, anyhow::Error> {
+        // * Parse attested claims, MSO, issuer public key, and issuer signature from DeviceResponse.
+        // * Construct witness variables from namespace, requested claims, rounds of claim hashes, MSO,
+        //   rounds of hash for issuer signature, issuer signature, SessionTranscript, rounds of hash
+        //   for device key signature, device key signature, and the time in RFC 3339 format.
+        // * Run two-circuit prover on witness and return proof.
+        todo!()
+    }
+}


### PR DESCRIPTION
This is an initial stab at what the JS API might look like. In all, I think we'll need the DeviceResponse, the namespace the claims are in, the list of which claims to disclose, the SessionTranscript, the device authentication signature, and the current time. I'm assuming for now that we take in the whole DeviceResponse CBOR blob, and parse out the mdoc MSO, along with the claims and nonces, but we could flip that around as well. Similarly, we'll probably want to take in the device authentication signature in some sort of ASN.1 format, but I have it down as just raw serialized scalars for now.

Since `wasm-bindgen` has some unusual restrictions on function parameter and return types, I wrote one function signature for use from Rust, and one for use from JS.

Here are the resulting TypeScript definitions.

```typescript
export enum CircuitVersion {
        V6 = 6,
}

export function prove(
        circuit_version: CircuitVersion,
        circuit: Uint8Array,
        device_response: Uint8Array,
        namespace: string,
        requested_claims: string[],
        session_transcript: Uint8Array,
        device_authentication_signature_r: Uint8Array,
        device_authentication_signature_s: Uint8Array,
        time: string
): Uint8Array;
```