### PR TITLE
Add input length checks to sumcheck module

### DIFF
--- a/src/constraints/proof_constraints.rs
+++ b/src/constraints/proof_constraints.rs
@@ -459,6 +459,24 @@ mod tests {
         )
         .unwrap();
 
+        for wrong_length in [
+            circuit.num_public_inputs() - 1,
+            circuit.num_public_inputs() + 1,
+        ] {
+            assert!(
+                LinearConstraints::from_proof(
+                    &circuit,
+                    evaluation.public_inputs(wrong_length),
+                    &mut transcript,
+                    &test_vector_proof,
+                )
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("wrong number of inputs")
+            );
+        }
+
         assert_eq!(
             linear_constraints.rhs,
             test_vector.constraints.linear_constraint_rhs()

--- a/src/sumcheck/prover.rs
+++ b/src/sumcheck/prover.rs
@@ -395,10 +395,50 @@ mod tests {
         assert!(proof_encoded == test_vector.serialized_sumcheck_proof);
     }
 
+    fn prove_input_length_validation<FE: ProofFieldElement>(
+        test_vector: CircuitTestVector,
+        circuit: Circuit,
+    ) {
+        let mut longer_input = test_vector.valid_inputs();
+        longer_input.push(FE::ZERO);
+
+        let evaluation: Evaluation<FE> = circuit.evaluate(&longer_input).unwrap();
+
+        let witness = Witness::fill_witness(
+            WitnessLayout::from_circuit(&circuit),
+            evaluation.private_inputs(circuit.num_public_inputs()),
+            || test_vector.pad(),
+        );
+
+        let mut transcript = Transcript::new(b"test").unwrap();
+
+        transcript
+            .write_byte_array(test_vector.ligero_commitment().as_bytes())
+            .unwrap();
+        initialize_transcript(
+            &mut transcript,
+            &circuit,
+            evaluation.public_inputs(circuit.num_public_inputs()),
+        )
+        .unwrap();
+        let error = SumcheckProver::new(&circuit)
+            .prove(&evaluation, &mut transcript, &witness)
+            .err()
+            .unwrap();
+
+        assert!(error.to_string().contains("wrong number of inputs"));
+    }
+
     #[wasm_bindgen_test(unsupported = test)]
     fn longfellow_rfc_1_87474f308020535e57a778a82394a14106f8be5b() {
         let (test_vector, circuit) = load_rfc();
         prove::<FieldP128>(test_vector, circuit);
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn longfellow_rfc_1_87474f308020535e57a778a82394a14106f8be5b_input_validation() {
+        let (test_vector, circuit) = load_rfc();
+        prove_input_length_validation::<FieldP128>(test_vector, circuit);
     }
 
     #[ignore = "slow test"]
@@ -406,6 +446,13 @@ mod tests {
     fn longfellow_mac() {
         let (test_vector, circuit) = load_mac();
         prove::<Field2_128>(test_vector, circuit);
+    }
+
+    #[ignore = "slow test"]
+    #[wasm_bindgen_test(unsupported = test)]
+    fn longfellow_mac_input_validation() {
+        let (test_vector, circuit) = load_mac();
+        prove_input_length_validation::<Field2_128>(test_vector, circuit);
     }
 
     #[wasm_bindgen_test(unsupported = test)]


### PR DESCRIPTION
This adds length checks to the sumcheck prover and verifier, to catch inputs of the wrong length early. I ran into issues when putting together #115 which would have been caught by these checks. Running the prover with the wrong input length otherwise results in disagreement on the witness layout, and thus the quadratic constraints, leading to a failure of the quadratic constraint test. Running the verifier with the wrong number of public inputs otherwise results in disagreement on the Fiat-Shamir transcript, leading to wrong challenges and failed tests.