### PR TITLE
Improvements to `Field2_128::inject()`

### DIFF
--- a/src/fields/field2_128/mod.rs
+++ b/src/fields/field2_128/mod.rs
@@ -79,15 +79,15 @@ impl Field2_128 {
         let mut subfield_encoding = 0u16;
 
         for rank in 0..Self::SUBFIELD_BIT_LENGTH {
-            if (remainder >> decomposition.first_nonzero[rank]) & 1 == 1 {
-                // Subtract the row-reduced element of beta from the value we started with
-                remainder ^= decomposition.upper[rank];
-                // Sum the corresponding coefficients of the linear combination of basis elements
-                // into the encoding.
-                subfield_encoding ^= decomposition.lower_inverse[rank];
-                // Recall that in GF(2), addition and subtraction are the same and in turn boil
-                // down to XOR
-            }
+            let bit = Choice::from(((remainder >> decomposition.first_nonzero[rank]) & 1) as u8);
+            // Subtract the row-reduced element of beta from the value we started with
+            remainder ^= u128::conditional_select(&0, &decomposition.upper[rank], bit);
+            // Sum the corresponding coefficients of the linear combination of basis elements into
+            // the encoding.
+            subfield_encoding ^=
+                u16::conditional_select(&0, &decomposition.lower_inverse[rank], bit);
+            // Recall that in GF(2), addition and subtraction are the same and in turn boil down to
+            // XOR
         }
 
         if remainder == 0 {


### PR DESCRIPTION
This makes `Field2_128::inject()` and `Field2_128::uninject()` constant-time, closing #93, and adds a variant of the former that can be specialized for inputs of different bit widths.

I did some rough benchmarking and napkin math to see how much skipping unnecessary iterations by using `inject_bits()` could save us. Different parts of the input use one GF(2^128) element per bit, or one GF(2^128) element per four bits, depending. The biggest contributors to witness size are the SHA-256 block witnesses, which take 51520 wires, and could be produced by 51520 calls to `inject_bits::<5>()`. On my machine, benchmarks show the difference between the two methods is 68ns - 20ns = 48ns. Multiplying this out, that's a 2.5ms savings for the SHA-256 block witnesses. Then we'd similarly save ~1ms on the SHA-256 input, which is encoded with one bit per wire, and a bit more for other smaller inputs. This is a small potential improvement. If we're shooting for an overall prove time of around a second, this could be close to half a percent. Since the additional code is so small, I think using `inject_bits()` is probably worth it.