### PR TITLE
Parse CBOR structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,10 +50,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64ct"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
 name = "block-buffer"
@@ -163,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +266,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +347,12 @@ name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "generic-array"
@@ -710,6 +757,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +791,27 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -941,6 +1019,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,12 +1057,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zk-cred-longfellow"
 version = "0.1.0"
 dependencies = [
  "aes",
  "anyhow",
+ "assert_matches",
  "byteorder",
+ "ciborium",
+ "ciborium-ll",
  "criterion",
  "crypto-common",
  "educe",
@@ -988,6 +1101,7 @@ dependencies = [
  "sha2",
  "subtle",
  "wasm-bindgen-test",
+ "x509-cert",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2024"
 aes = "0.8.4"
 anyhow = "1"
 byteorder = "1.5.0"
+ciborium = "0.2.2"
+ciborium-ll = "0.2.2"
 crypto-common = "0.1.6"
 educe = { version = "0.6.0", features = ["Debug", "Clone", "Copy", "Hash", "Default"] }
 getrandom = { version = "0.3.3", features = ["wasm_js"] }
@@ -18,6 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 sha2 = "0.10.9"
 subtle = "2.6.1"
+x509-cert = { version = "0.2.5", default-features = false, features = ["hazmat", "std"] }
 zstd = "0.13.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
@@ -27,6 +30,7 @@ criterion = { version = "0.8.0", features = ["html_reports"] }
 criterion = { version = "0.8.0", default-features = false }
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 hex = { version = "0.4.3", features = ["serde"] }
 num-traits = "0.2.19"
 pretty_assertions = "1.4.1"

--- a/src/fields/fieldp256/mod.rs
+++ b/src/fields/fieldp256/mod.rs
@@ -73,7 +73,7 @@ impl FieldP256 {
     ///
     /// This is equivalent to the implementation of `TryFrom<&[u8; 32]>`, but it can be called from
     /// const contexts.
-    pub(super) const fn try_from_bytes_const(value: &[u8; 32]) -> Result<Self, &'static str> {
+    pub(crate) const fn try_from_bytes_const(value: &[u8; 32]) -> Result<Self, &'static str> {
         // We have to use an open-coded for loop instead of iterator combinators due to the present
         // limitations of const functions.
         let mut i = 31;

--- a/src/mdoc_zk/ec.rs
+++ b/src/mdoc_zk/ec.rs
@@ -1,0 +1,150 @@
+//! Elliptic curve cryptography utilities.
+
+use crate::{
+    Codec,
+    fields::{CodecFieldElement, FieldElement, fieldp256::FieldP256},
+};
+use anyhow::anyhow;
+use subtle::{Choice, ConditionallySelectable};
+
+/// Decodes an encoded P-256 elliptic curve point.
+///
+/// Returns `None` if the encoding represents the point at infinity.
+///
+/// See <https://www.secg.org/sec1-v2.pdf#page=17>.
+pub(super) fn decode_point(bytes: &[u8]) -> Result<Option<(FieldP256, FieldP256)>, anyhow::Error> {
+    if bytes == [0] {
+        // Point at infinity.
+        Ok(None)
+    } else if bytes.len() == FieldP256::num_bytes() + 1 {
+        // Compressed encoding.
+        //
+        // Unwrap safety: we just checked the length.
+        let (first, rest) = bytes.split_first().unwrap();
+        let x = decode_field_element(rest.try_into().unwrap())?;
+        let y_parity = match first {
+            2 | 3 => Choice::from(*first & 1),
+            _ => {
+                return Err(anyhow!(
+                    "invalid elliptic curve point encoding, wrong prefix byte"
+                ));
+            }
+        };
+        let alpha = x.square() * x + P256_A * x + P256_B;
+        let beta = alpha
+            .sqrt()
+            .into_option()
+            .ok_or_else(|| anyhow!("invalid elliptic curve point encoding, x-coordinate does not correspond to any points on the curve"))?;
+        let beta_encoded = beta.get_encoded()?;
+        let beta_parity = Choice::from(beta_encoded[0] & 1);
+        let y = FieldP256::conditional_select(&beta, &-beta, y_parity ^ beta_parity);
+        Ok(Some((x, y)))
+    } else if bytes.len() == 2 * FieldP256::num_bytes() + 1 {
+        // Uncompressed encoding.
+        //
+        // Unwrap safety: we just checked the length.
+        let (first, rest) = bytes.split_first().unwrap();
+        let (bytes_x, bytes_y) = rest.split_at(FieldP256::num_bytes());
+        if *first != 4 {
+            return Err(anyhow!(
+                "invalid elliptic curve point encoding, wrong prefix byte"
+            ));
+        }
+        let x = decode_field_element(bytes_x.try_into().unwrap())?;
+        let y = decode_field_element(bytes_y.try_into().unwrap())?;
+        if y.square() != x.square() * x + P256_A * x + P256_B {
+            return Err(anyhow!(
+                "invalid elliptic curve point encoding, coordinates are not on the curve"
+            ));
+        }
+        Ok(Some((x, y)))
+    } else {
+        Err(anyhow!(
+            "encoded elliptic curve point has an invalid length"
+        ))
+    }
+}
+
+/// Decode a big-endian serialized field element.
+fn decode_field_element(bytes: &[u8; 32]) -> Result<FieldP256, anyhow::Error> {
+    // SEC 1 uses big-endian encoding, but fiat-crypto uses little-endian encoding.
+    let mut reversed = [0u8; 32];
+    reversed.copy_from_slice(bytes);
+    reversed.reverse();
+    FieldP256::try_from(&reversed)
+}
+
+/// One of the two coefficients of the P-256 elliptic curve.
+const P256_A: FieldP256 = {
+    match FieldP256::try_from_bytes_const(&[
+        0xfc, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xff, 0xff,
+        0xff, 0xff,
+    ]) {
+        Ok(value) => value,
+        Err(_) => panic!("could not convert constant to field element"),
+    }
+};
+/// One of the two coefficients of the P-256 elliptic curve.
+const P256_B: FieldP256 = {
+    match FieldP256::try_from_bytes_const(&[
+        0x4b, 0x60, 0xd2, 0x27, 0x3e, 0x3c, 0xce, 0x3b, 0xf6, 0xb0, 0x53, 0xcc, 0xb0, 0x06, 0x1d,
+        0x65, 0xbc, 0x86, 0x98, 0x76, 0x55, 0xbd, 0xeb, 0xb3, 0xe7, 0x93, 0x3a, 0xaa, 0xd8, 0x35,
+        0xc6, 0x5a,
+    ]) {
+        Ok(value) => value,
+        Err(_) => panic!("could not convert constant to field element"),
+    }
+};
+
+#[cfg(test)]
+mod tests {
+    use crate::mdoc_zk::ec::decode_point;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_decode_point() {
+        // Identity element
+        assert_eq!(decode_point(&[0]).unwrap(), None);
+        // Generator point, compressed form
+        let gen_1 = decode_point(&[
+            0x03, 0x6b, 0x17, 0xd1, 0xf2, 0xe1, 0x2c, 0x42, 0x47, 0xf8, 0xbc, 0xe6, 0xe5, 0x63,
+            0xa4, 0x40, 0xf2, 0x77, 0x03, 0x7d, 0x81, 0x2d, 0xeb, 0x33, 0xa0, 0xf4, 0xa1, 0x39,
+            0x45, 0xd8, 0x98, 0xc2, 0x96,
+        ])
+        .unwrap()
+        .unwrap();
+        // Generator point, uncompressed form
+        let gen_2 = decode_point(&[
+            0x04, 0x6b, 0x17, 0xd1, 0xf2, 0xe1, 0x2c, 0x42, 0x47, 0xf8, 0xbc, 0xe6, 0xe5, 0x63,
+            0xa4, 0x40, 0xf2, 0x77, 0x03, 0x7d, 0x81, 0x2d, 0xeb, 0x33, 0xa0, 0xf4, 0xa1, 0x39,
+            0x45, 0xd8, 0x98, 0xc2, 0x96, 0x4f, 0xe3, 0x42, 0xe2, 0xfe, 0x1a, 0x7f, 0x9b, 0x8e,
+            0xe7, 0xeb, 0x4a, 0x7c, 0x0f, 0x9e, 0x16, 0x2b, 0xce, 0x33, 0x57, 0x6b, 0x31, 0x5e,
+            0xce, 0xcb, 0xb6, 0x40, 0x68, 0x37, 0xbf, 0x51, 0xf5,
+        ])
+        .unwrap()
+        .unwrap();
+        assert_eq!(gen_1, gen_2);
+        // Off-curve point, uncompressed form
+        decode_point(&[
+            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ])
+        .unwrap_err();
+        // Coordinate beyond field modulus
+        decode_point(&[
+            0x03, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff,
+        ])
+        .unwrap_err();
+        // Invalid encoded length
+        decode_point(&[0, 0]).unwrap_err();
+        // Invalid prefixes
+        decode_point(&[0x5; 33]).unwrap_err();
+        decode_point(&[0x5; 65]).unwrap_err();
+    }
+}

--- a/src/mdoc_zk/mdoc/cose.rs
+++ b/src/mdoc_zk/mdoc/cose.rs
@@ -1,0 +1,447 @@
+//! Parsing of COSE CBOR structures.
+
+use serde::{
+    Deserialize,
+    de::{Error, IgnoredAny, MapAccess, SeqAccess, Visitor},
+};
+use std::fmt;
+
+/// COSE_Sign1 from RFC 8152.
+#[derive(Debug, Deserialize)]
+#[serde(from = "CoseSign1Tuple")]
+pub(super) struct CoseSign1 {
+    /// Protected header parameters.
+    ///
+    /// If there are no protected header parameters, this will be the empty byte string. Otherwise,
+    /// it will be the CBOR encoding of a map.
+    #[allow(unused)]
+    pub(super) protected: Vec<u8>,
+    /// Unprotected header parameters.
+    pub(super) unprotected: CoseUnprotectedHeaders,
+    /// The message that is the subject of the signature.
+    ///
+    /// This will be `None` for detached signatures.
+    pub(super) payload: Option<Vec<u8>>,
+    /// The signature itself.
+    pub(super) signature: Vec<u8>,
+}
+
+impl From<CoseSign1Tuple> for CoseSign1 {
+    fn from(CoseSign1Tuple(protected, unprotected, payload, signature): CoseSign1Tuple) -> Self {
+        Self {
+            protected,
+            unprotected,
+            payload,
+            signature,
+        }
+    }
+}
+
+/// Helper type for deserializing COSE_Sign1 from a CBOR list.
+#[derive(Deserialize)]
+struct CoseSign1Tuple(Vec<u8>, CoseUnprotectedHeaders, Option<Vec<u8>>, Vec<u8>);
+
+/// Unprotected headers from a COSE_Sign1 message.
+///
+/// This is defined as a map from numbers or strings to various kinds of values. We only parse the
+/// kinds of parameters that we care about.
+#[derive(Debug)]
+pub(super) struct CoseUnprotectedHeaders {
+    pub(super) x5chain: Option<CoseX509>,
+}
+
+impl<'de> Deserialize<'de> for CoseUnprotectedHeaders {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(CoseUnprotectedHeadersVisitor)
+    }
+}
+
+struct CoseUnprotectedHeadersVisitor;
+
+impl<'de> Visitor<'de> for CoseUnprotectedHeadersVisitor {
+    type Value = CoseUnprotectedHeaders;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a map")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut x5chain = None;
+
+        while let Some(key) = map.next_key()? {
+            match key {
+                CoseLabel::Number(header_parameters::X5CHAIN) => {
+                    x5chain = Some(map.next_value()?);
+                }
+                _ => {
+                    map.next_value::<IgnoredAny>()?;
+                }
+            }
+        }
+
+        Ok(CoseUnprotectedHeaders { x5chain })
+    }
+}
+
+/// Map keys used throughout COSE.
+#[derive(Debug, PartialEq, Eq, Hash, Deserialize)]
+#[serde(untagged)]
+enum CoseLabel {
+    Number(i64),
+    String(String),
+}
+
+/// Labels for COSE header parameters.
+///
+/// See <https://www.iana.org/assignments/cose/cose.xhtml#header-parameters>.
+mod header_parameters {
+    /// The label for the x5chain header parameter.
+    pub(super) const X5CHAIN: i64 = 33;
+}
+
+/// COSE_X509 from RFC 9360.
+///
+/// This can be either `bstr` or `[ bstr ]` on the wire. We represent both cases as a nested vector.
+/// Note that we have to jump through some hoops to detect the difference via serde.
+#[derive(Debug)]
+pub(super) struct CoseX509(pub(super) Vec<Vec<u8>>);
+
+impl<'de> Deserialize<'de> for CoseX509 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(CoseX509Visitor).map(Self)
+    }
+}
+
+struct CoseX509Visitor;
+
+impl<'de> Visitor<'de> for CoseX509Visitor {
+    type Value = Vec<Vec<u8>>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("byte array or a list of byte arrays")
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(vec![v.to_vec()])
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(vec![v])
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let size_hint = seq.size_hint();
+        match seq.next_element()? {
+            Some(ByteOrBytes::Byte(byte)) => {
+                let mut inner = Vec::with_capacity(size_hint.unwrap_or_default());
+                inner.push(byte);
+                while let Some(byte) = seq.next_element::<u8>()? {
+                    inner.push(byte);
+                }
+                Ok(vec![inner])
+            }
+            Some(ByteOrBytes::Bytes(bytes)) => {
+                let mut output = Vec::with_capacity(size_hint.unwrap_or_default());
+                output.push(bytes);
+                while let Some(bytes) = seq.next_element::<Vec<u8>>()? {
+                    output.push(bytes);
+                }
+                Ok(output)
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ByteOrBytes {
+    Byte(u8),
+    Bytes(Vec<u8>),
+}
+
+#[derive(Debug)]
+pub(super) struct CoseKey {
+    pub(super) x: Vec<u8>,
+    pub(super) y: Vec<u8>,
+}
+
+impl<'de> Deserialize<'de> for CoseKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(CoseKeyVisitor)
+    }
+}
+
+struct CoseKeyVisitor;
+
+impl<'de> Visitor<'de> for CoseKeyVisitor {
+    type Value = CoseKey;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("map")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut kty_seen = false;
+        let mut crv_seen = false;
+        let mut x = None;
+        let mut y = None;
+
+        while let Some(key) = map.next_key::<CoseLabel>()? {
+            match key {
+                CoseLabel::Number(key_parameters::KTY) => {
+                    if kty_seen {
+                        return Err(A::Error::duplicate_field("kty"));
+                    }
+                    kty_seen = true;
+                    let key_type = map.next_value::<CoseLabel>()?;
+                    let CoseLabel::Number(key_types::EC2) = key_type else {
+                        return Err(A::Error::custom("unsupported COSE key type"));
+                    };
+                }
+                CoseLabel::Number(key_parameters::KTY_2_CRV) => {
+                    if crv_seen {
+                        return Err(A::Error::duplicate_field("crv"));
+                    }
+                    crv_seen = true;
+                    let curve = map.next_value::<CoseLabel>()?;
+                    let CoseLabel::Number(elliptic_curves::P256) = curve else {
+                        return Err(A::Error::custom("unsupported elliptic curve"));
+                    };
+                }
+                CoseLabel::Number(key_parameters::KTY_2_X) => {
+                    if x.is_some() {
+                        return Err(A::Error::duplicate_field("x"));
+                    }
+                    x = Some(map.next_value()?);
+                }
+                CoseLabel::Number(key_parameters::KTY_2_Y) => {
+                    if y.is_some() {
+                        return Err(A::Error::duplicate_field("y"));
+                    }
+                    y = Some(map.next_value()?);
+                }
+                _ => {
+                    map.next_value::<IgnoredAny>()?;
+                }
+            }
+        }
+
+        if !kty_seen {
+            return Err(A::Error::missing_field("kty"));
+        }
+        if !crv_seen {
+            return Err(A::Error::missing_field("crv"));
+        }
+
+        Ok(CoseKey {
+            x: x.ok_or_else(|| A::Error::missing_field("x"))?,
+            y: y.ok_or_else(|| A::Error::missing_field("y"))?,
+        })
+    }
+}
+
+/// Labels for COSE key parameters.
+///
+/// See <https://www.iana.org/assignments/cose/cose.xhtml#key-common-parameters> and
+/// <https://www.iana.org/assignments/cose/cose.xhtml#key-type-parameters>.
+mod key_parameters {
+    /// The label for the key type parameter.
+    pub(super) const KTY: i64 = 1;
+    /// The label for the curve identifier parameter.
+    pub(super) const KTY_2_CRV: i64 = -1;
+    /// The label for the x-coordinate of the private key.
+    pub(super) const KTY_2_X: i64 = -2;
+    /// The label for the y-coordinate of the private key.
+    pub(super) const KTY_2_Y: i64 = -3;
+}
+
+/// Labels for COSE key types.
+///
+/// See <https://www.iana.org/assignments/cose/cose.xhtml#key-type>.
+mod key_types {
+    /// The label for elliptic curve keys with x- and y-coordinates.
+    pub(super) const EC2: i64 = 2;
+}
+
+/// Labels for elliptic curves.
+///
+/// See <https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves>.
+mod elliptic_curves {
+    /// The label for P-256.
+    pub(super) const P256: i64 = 1;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::mdoc_zk::mdoc::{
+        CoseKey, CoseSign1,
+        cose::{CoseLabel, CoseUnprotectedHeaders, CoseX509},
+    };
+    use assert_matches::assert_matches;
+    use ciborium::{Value, cbor};
+    use serde::de::DeserializeOwned;
+    use std::io;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_cose_sign1() {
+        let parsed = round_trip::<CoseSign1>(cbor!([b"", {}, b"payload", b"signature"]));
+        assert_eq!(parsed.protected, b"");
+        assert!(parsed.unprotected.x5chain.is_none());
+        assert_eq!(parsed.payload.unwrap(), b"payload");
+        assert_eq!(parsed.signature, b"signature");
+
+        let parsed = round_trip::<CoseSign1>(cbor!([b"", {}, null, b"signature"]));
+        assert!(parsed.payload.is_none());
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_headers() {
+        assert!(
+            round_trip::<CoseUnprotectedHeaders>(cbor!({}))
+                .x5chain
+                .is_none()
+        );
+        assert!(
+            round_trip::<CoseUnprotectedHeaders>(cbor!({-5 => {}}))
+                .x5chain
+                .is_none()
+        );
+        assert!(
+            round_trip::<CoseUnprotectedHeaders>(cbor!({"other" => {}}))
+                .x5chain
+                .is_none()
+        );
+        assert_eq!(
+            round_trip::<CoseUnprotectedHeaders>(cbor!({33 => b"cert"}))
+                .x5chain
+                .unwrap()
+                .0,
+            vec![b"cert"]
+        );
+    }
+
+    #[wasm_bindgen_test(unsupported  =test)]
+    fn test_label() {
+        assert_matches!(round_trip::<>(cbor!(-1)), CoseLabel::Number(number) => assert_eq!(number, -1));
+        assert_matches!(round_trip::<>(cbor!("other")), CoseLabel::String(string) => assert_eq!(string, "other"));
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_cose_x509() {
+        assert_eq!(round_trip::<CoseX509>(cbor!(b"test")).0, [b"test"]);
+        assert_eq!(
+            round_trip::<CoseX509>(cbor!([b't', b'e', b's', b't'])).0,
+            [b"test"]
+        );
+        assert_eq!(round_trip::<CoseX509>(cbor!([b"test"])).0, [b"test"]);
+        assert_eq!(
+            round_trip::<CoseX509>(cbor!([b"cert1", b"cert2"])).0,
+            [b"cert1", b"cert2"]
+        );
+        assert!(round_trip::<CoseX509>(cbor!([])).0.is_empty());
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_cose_key() {
+        let key = round_trip::<CoseKey>(cbor!({
+            1 => 2, // kty = EC2
+            -1 => 1, // crv = P-256
+            -2 => b"x", // x-coordinate
+            -3 => b"y", // y-coordinate
+        }));
+        assert_eq!(key.x, b"x");
+        assert_eq!(key.y, b"y");
+
+        // Wrong values for expected key parameters.
+        round_trip_err::<CoseKey>(cbor!({
+            1 => 1,
+            -1 => 1,
+            -2 => b"",
+            -3 => b"",
+        }));
+        round_trip_err::<CoseKey>(cbor!({
+            1 => 2,
+            -1 => 2,
+            -2 => b"",
+            -3 => b"",
+        }));
+
+        // Extra key-value pair.
+        round_trip_err::<CoseKey>(cbor!({
+            1 => 2,
+            -1 => 2,
+            -2 => b"",
+            -3 => b"",
+            "other" => b"other",
+            "map" => {
+                1 => 2,
+            },
+        }));
+
+        // Missing key parameters.
+        round_trip_err::<CoseKey>(cbor!({
+            -1 => 1,
+            -2 => b"",
+            -3 => b"",
+        }));
+        round_trip_err::<CoseKey>(cbor!({
+            1 => 2,
+            -2 => b"",
+            -3 => b"",
+        }));
+        round_trip_err::<CoseKey>(cbor!({
+            1 => 2,
+            -1 => 1,
+            -3 => b"",
+        }));
+        round_trip_err::<CoseKey>(cbor!({
+            1 => 2,
+            -1 => 1,
+            -2 => b"",
+        }));
+    }
+
+    fn round_trip<T: DeserializeOwned>(result: Result<Value, ciborium::value::Error>) -> T {
+        let value = result.unwrap();
+        let mut buffer = Vec::new();
+        ciborium::into_writer(&value, &mut buffer).unwrap();
+        ciborium::from_reader(buffer.as_slice()).unwrap()
+    }
+
+    fn round_trip_err<T: DeserializeOwned>(
+        result: Result<Value, ciborium::value::Error>,
+    ) -> ciborium::de::Error<io::Error> {
+        let value = result.unwrap();
+        let mut buffer = Vec::new();
+        ciborium::into_writer(&value, &mut buffer).unwrap();
+        ciborium::from_reader::<T, _>(buffer.as_slice())
+            .err()
+            .unwrap()
+    }
+}

--- a/src/mdoc_zk/mdoc/mod.rs
+++ b/src/mdoc_zk/mdoc/mod.rs
@@ -1,0 +1,250 @@
+//! Parsing of mdoc CBOR structures.
+
+use crate::{
+    fields::fieldp256::FieldP256,
+    mdoc_zk::{
+        ec::decode_point,
+        mdoc::cose::{CoseKey, CoseSign1},
+    },
+};
+use anyhow::{Context, anyhow};
+use ciborium::tag;
+use serde::{Deserialize, de::IgnoredAny};
+use std::collections::HashMap;
+use x509_cert::{
+    certificate::{CertificateInner, Raw},
+    der::{Decode, SliceReader},
+    spki::ObjectIdentifier,
+};
+
+mod cose;
+
+/// Fields parsed from an mdoc credential.
+pub(super) struct Mdoc {
+    // Issuer signature information.
+    pub(super) issuer_public_key_x: FieldP256,
+    pub(super) issuer_public_key_y: FieldP256,
+    #[allow(unused)]
+    pub(super) issuer_signature_payload: Vec<u8>,
+    #[allow(unused)]
+    pub(super) issuer_signature: Vec<u8>,
+
+    // Validity information.
+    #[allow(unused)]
+    pub(super) valid_from: String,
+    #[allow(unused)]
+    pub(super) valid_until: String,
+
+    // Authentication of the mdoc.
+    #[allow(unused)]
+    pub(super) device_public_key_x: Vec<u8>,
+    #[allow(unused)]
+    pub(super) device_public_key_y: Vec<u8>,
+    #[allow(unused)]
+    pub(super) doc_type: String,
+    #[allow(unused)]
+    pub(super) device_namespaces_bytes: Vec<u8>,
+    #[allow(unused)]
+    pub(super) device_signature: Vec<u8>,
+
+    // Attributes.
+    #[allow(unused)]
+    pub(super) attribute_preimages: HashMap<String, Vec<Vec<u8>>>,
+    #[allow(unused)]
+    pub(super) attribute_digests: HashMap<String, HashMap<usize, Vec<u8>>>,
+}
+
+pub(super) fn parse_device_response(bytes: &[u8]) -> Result<Mdoc, anyhow::Error> {
+    let device_response = ciborium::from_reader::<DeviceResponse, _>(bytes)
+        .context("could not parse DeviceResponse")?;
+
+    if device_response.status != 0 {
+        return Err(anyhow!(
+            "status of DeviceResponse was {}",
+            device_response.status
+        ));
+    }
+
+    let Some(documents) = device_response
+        .documents
+        .filter(|documents| !documents.is_empty())
+    else {
+        if device_response
+            .zk_documents
+            .is_some_and(|zk_documents| !zk_documents.is_empty())
+        {
+            return Err(anyhow!(
+                "DeviceResponse contains a ZkDocument, not a Document"
+            ));
+        }
+        return Err(anyhow!("DeviceResponse does not contain any Document"));
+    };
+
+    if documents.len() != 1 {
+        return Err(anyhow!("DeviceResponse contains multiple Documents"));
+    }
+    let document = documents.into_iter().next().unwrap();
+
+    let certificate_bytes = document
+        .issuer_signed
+        .issuer_auth
+        .unprotected
+        .x5chain
+        .as_ref()
+        .ok_or_else(|| anyhow!("missing certificate chain"))?
+        .0
+        .first()
+        .ok_or_else(|| anyhow!("empty certificate chain"))?;
+    let certificate = CertificateInner::<Raw>::decode(
+        &mut SliceReader::new(certificate_bytes.as_slice()).context("certificate is too long")?,
+    )
+    .context("could not parse issuer certificate")?;
+
+    let spki = &certificate.tbs_certificate.subject_public_key_info;
+    if spki.algorithm.oid != OID_EC_PUBLIC_KEY {
+        return Err(anyhow!("issuer certificate has wrong public key algorithm"));
+    }
+    let Some(public_key_params) = spki.algorithm.parameters.as_ref() else {
+        return Err(anyhow!(
+            "issuer certificate subject public key information is missing parameters"
+        ));
+    };
+    let curve_oid = public_key_params
+        .decode_as::<ObjectIdentifier>()
+        .context("could not decode public key algorithm parameters")?;
+    if curve_oid != OID_CURVE_P256 {
+        return Err(anyhow!("issuer public key uses wrong elliptic curve"));
+    }
+
+    let public_key_bytes = spki
+        .subject_public_key
+        .as_bytes()
+        .ok_or_else(|| anyhow!("public key length is not octet aligned"))?;
+    let (issuer_public_key_x, issuer_public_key_y) = decode_point(public_key_bytes)?
+        .ok_or_else(|| anyhow!("issuer public key was the point at infinity"))?;
+
+    let msob = ciborium::from_reader::<MobileSecurityObjectBytes, _>(
+        document
+            .issuer_signed
+            .issuer_auth
+            .payload
+            .as_ref()
+            .ok_or_else(|| anyhow!("issuer signature is missing payload"))?
+            .as_slice(),
+    )
+    .context("could not parse MobileSecurityObjectBytes")?;
+    let mso = ciborium::from_reader::<MobileSecurityObject, _>(msob.0.as_slice())
+        .context("could not parse MobileSecurityObject")?;
+    // TODO: Need to use ciborium-ll to parse the MSO instead, so that we can get byte offsets of
+    // its fields.
+
+    let DeviceAuth::DeviceSignature(device_signature) = document.device_signed.device_auth else {
+        return Err(anyhow!("DeviceAuth used MAC instead of signature"));
+    };
+
+    let attribute_preimages = document
+        .issuer_signed
+        .name_spaces
+        .ok_or_else(|| anyhow!("issuer signed namespaces are missing"))?
+        .into_iter()
+        .map(|(namespace, items)| {
+            (
+                namespace,
+                items.into_iter().map(|item| item.0).collect::<Vec<_>>(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    Ok(Mdoc {
+        issuer_public_key_x,
+        issuer_public_key_y,
+        issuer_signature_payload: document.issuer_signed.issuer_auth.payload.unwrap(),
+        issuer_signature: document.issuer_signed.issuer_auth.signature,
+        valid_from: mso.validity_info.valid_from.0,
+        valid_until: mso.validity_info.valid_until.0,
+        device_public_key_x: mso.device_key_info.device_key.x,
+        device_public_key_y: mso.device_key_info.device_key.y,
+        doc_type: document.doc_type,
+        device_namespaces_bytes: document.device_signed.name_spaces.0,
+        device_signature: device_signature.signature,
+        attribute_preimages,
+        attribute_digests: mso.value_digests,
+    })
+}
+
+/// The algorithm identifier for the elliptic curve public key type, from ANSI X9.62.
+const OID_EC_PUBLIC_KEY: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.2.1");
+/// The curve identifier for P-256/prime256v1/secp256r1.
+const OID_CURVE_P256: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.3.1.7");
+
+/// DeviceResponse from ISO 18013-5.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeviceResponse {
+    documents: Option<Vec<Document>>,
+    zk_documents: Option<Vec<ZkDocument>>,
+    status: u64,
+}
+
+/// Document from ISO 18013-5.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Document {
+    doc_type: String,
+    issuer_signed: IssuerSigned,
+    device_signed: DeviceSigned,
+}
+
+/// IssuerSigned from ISO 18013-5.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IssuerSigned {
+    issuer_auth: CoseSign1,
+    name_spaces: Option<HashMap<String, Vec<tag::Required<Vec<u8>, 24>>>>,
+}
+
+/// DeviceSigned from ISO 18013-5.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeviceSigned {
+    name_spaces: tag::Required<Vec<u8>, 24>,
+    device_auth: DeviceAuth,
+}
+
+/// DeviceAuth from ISO 18013-5.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum DeviceAuth {
+    DeviceSignature(CoseSign1),
+    DeviceMac(IgnoredAny),
+}
+
+/// ZkDocument from ISO 18013-5.
+#[derive(Debug, Deserialize)]
+struct ZkDocument {}
+
+type MobileSecurityObjectBytes = tag::Required<Vec<u8>, 24>;
+
+/// MobileSecurityObject from ISO 18013-5.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MobileSecurityObject {
+    value_digests: HashMap<String, HashMap<usize, Vec<u8>>>,
+    device_key_info: DeviceKeyInfo,
+    validity_info: ValidityInfo,
+}
+
+/// DeviceKeyInfo from ISO 18013-5.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeviceKeyInfo {
+    device_key: CoseKey,
+}
+
+/// ValidityInfo from ISO 18013-5.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ValidityInfo {
+    valid_from: tag::Required<String, 0>,
+    valid_until: tag::Required<String, 0>,
+}


### PR DESCRIPTION
This adds support for parsing various CBOR structures, including the DeviceResponse, the MSO, and a few COSE-related structs. I collected most of the fields we'll need into one flattened struct. Using this, I filled in the issuer public key coordinates in the circuit input, which are the first two public inputs after the constant one. I'll need to revisit the innermost CBOR layer in the future, in order to rewrite it using `ciborium-ll` to get byte offsets, but this gives us a good starting place.