### PR TITLE
Use sparse array in sumcheck

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -288,54 +288,31 @@ impl<FE: CodecFieldElement> Circuit<FE> {
     /// Because Q and Z are disjoint, this amounts to traversing the layer's quads, identifying Z
     /// quads (the ones whose value is zero) and setting their value to beta. This is then compiled
     /// into a three-dimensional array indexed by gate index, left wire index, and right wire index.
-    // Once SparseSumcheckArray can replace the dense array, this method will return a single value
-    // and we can drop the #[allow].
-    #[allow(clippy::type_complexity)]
     pub fn combined_quad(
         &self,
         layer_index: usize,
         beta: FE,
-    ) -> Result<(Vec<Vec<Vec<FE>>>, SparseSumcheckArray<FE>), anyhow::Error> {
-        // The number of gates on this layer is the number of input wires to the next layer
-        let num_gates = if layer_index == 0 {
-            self.num_outputs()
-        } else {
-            self.layers[layer_index - 1].num_wires()
-        };
-
-        // Outer vector: index by gate number
-        let mut combined_quad = vec![
-            // Inner vector: index by left wire number
-            vec![
-                // Innermost vector: index by right wire number
-                vec![FE::ZERO; self.layers[layer_index].num_wires()];
-                self.layers[layer_index].num_wires()
-            ];
-            num_gates
-        ];
-
+    ) -> Result<SparseSumcheckArray<FE>, anyhow::Error> {
         let mut sparse_quad = Vec::with_capacity(self.layers[layer_index].quads.len());
 
         for quad in &self.layers[layer_index].quads {
             let quad_value: FE = self.constant(quad.const_table_index())?;
-            let coefficient = if quad_value.is_zero().into() {
-                beta
-            } else {
-                quad_value
-            };
-
-            combined_quad[quad.gate_index()][quad.left_wire_index()][quad.right_wire_index()] =
-                coefficient;
 
             sparse_quad.push(SparseQuadElement {
                 gate_index: quad.gate_index,
                 left_wire_index: quad.left_wire_index,
                 right_wire_index: quad.right_wire_index,
-                coefficient,
+                coefficient: if quad_value.is_zero().into() {
+                    beta
+                } else {
+                    quad_value
+                },
             });
         }
 
-        Ok((combined_quad, SparseSumcheckArray::from(sparse_quad)))
+        assert_eq!(sparse_quad.len(), self.layers[layer_index].quads.len());
+
+        Ok(SparseSumcheckArray::from(sparse_quad))
     }
 }
 

--- a/src/ligero/prover.rs
+++ b/src/ligero/prover.rs
@@ -475,7 +475,6 @@ mod tests {
         prove::<FieldP128>(test_vector, circuit);
     }
 
-    #[ignore = "slow test"]
     #[wasm_bindgen_test(unsupported = test)]
     fn longfellow_mac() {
         let (test_vector, circuit) = load_mac();

--- a/src/ligero/verifier.rs
+++ b/src/ligero/verifier.rs
@@ -257,7 +257,6 @@ mod tests {
         verify::<FieldP128>(test_vector, circuit);
     }
 
-    #[ignore = "slow test"]
     #[wasm_bindgen_test(unsupported = test)]
     fn longfellow_mac() {
         let (test_vector, circuit) = load_mac();

--- a/src/sumcheck/bind.rs
+++ b/src/sumcheck/bind.rs
@@ -1,83 +1,38 @@
-//! Array wrappers implemeniting sumcheck arrays and the `bind` and `bindv` functions from [1].
+//! Extension trait implementing sumcheck arrays and the `bind` functions from [1] on top of
+//! `Vec<FieldElement>`.
 //!
 //! [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-6.1
 
 use crate::fields::FieldElement;
-use std::iter::repeat;
 
 pub mod sparse;
 #[cfg(test)]
 pub mod test_vector;
 
-/// An array of field elements, possibly multi-dimensional, conforming to the sumcheck array
-/// convention of [6.1][1]:
+/// An dense array of field elements conforming to the sumcheck array convention of [6.1][1]:
 ///
 /// > The sumcheck array `A[i]` is implicitly assumed to be defined for all nonnegative integers i,
 /// > padding with zeroes as necessary.
 ///
 /// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-6.1
-pub trait SumcheckArray<FieldElement>: Sized {
-    type Index: Copy + Clone + std::fmt::Debug;
-
+pub trait DenseSumcheckArray<FieldElement>: Sized {
     /// Retrieve the element at the index, or zero if no element is defined for the index.
-    fn element(&self, index: Self::Index) -> FieldElement;
+    fn element(&self, index: usize) -> FieldElement;
 
-    /// Bind an arbitrary dimension array of field elements to a one-dimensional array of field
-    /// elements.
+    /// Bind a array of field elements to a single field element, in-place.
     ///
-    /// This corresponds to `bindv()` from [6.1][1]. The function `bind()` can be realized by
-    /// passing a slice containing a single element.
+    /// This corresponds to `bind()` from [6.1][1].
     ///
     /// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-6.1
-    fn bind(&self, binding: &[FieldElement]) -> Self;
-
-    /// Same as `Self::bind`, but (1) does the binding in place and (2) the binding can only be a
-    /// single field element.
-    fn bind_in_place(&mut self, binding: FieldElement);
-
-    /// Multiply each element in the array by the scalar.
-    // TODO: provide in-place version?
-    fn scale(&self, scalar: FieldElement) -> Self;
-
-    /// Transpose the last two dimensions of the array. This only really makes sense to do if the
-    /// array is two-dimensional or has been reduced to two dimensions by binding and if it is a
-    /// rectangular array.
-    // TODO: provide in-place version?
-    fn transpose(&self) -> Self;
+    fn bind(&mut self, binding: FieldElement);
 }
 
-impl<FE: FieldElement> SumcheckArray<FE> for Vec<FE> {
-    type Index = usize;
-
+impl<FE: FieldElement> DenseSumcheckArray<FE> for Vec<FE> {
     fn element(&self, index: usize) -> FE {
         *self.get(index).unwrap_or(&FE::ZERO)
     }
 
-    fn bind(&self, binding: &[FE]) -> Self {
-        // Specification interpretation verification: we expect to be binding down to a single
-        // element, but no further.
-        assert!(
-            binding.is_empty() || self.len() > 1,
-            "binding over a dimension that's already reduced to a single element"
-        );
-
-        let mut bound = self.clone();
-        for binding_element in binding {
-            // B[i] = (1 - x) * A[2 * i] + x * A[2 * i + 1]
-            // The back half of B[i] will always be zero so we can skip computing those elements
-            let new_len = bound.len().div_ceil(2);
-            for index in 0..new_len {
-                bound[index] = (FE::ONE - binding_element) * bound.element(2 * index)
-                    + *binding_element * bound.element(2 * index + 1)
-            }
-
-            bound.truncate(new_len);
-        }
-
-        bound
-    }
-
-    fn bind_in_place(&mut self, binding: FE) {
+    fn bind(&mut self, binding: FE) {
         assert!(
             self.len() > 1,
             "binding over a vector that's already reduced to a single element"
@@ -93,252 +48,18 @@ impl<FE: FieldElement> SumcheckArray<FE> for Vec<FE> {
 
         self.truncate(new_len);
     }
-
-    fn scale(&self, scalar: FE) -> Self {
-        self.iter().map(|element| scalar * element).collect()
-    }
-
-    fn transpose(&self) -> Self {
-        // no-op: can't transpose a 1D array
-        self.clone()
-    }
 }
 
-impl<FE: FieldElement> SumcheckArray<FE> for Vec<Vec<FE>> {
-    type Index = [usize; 2];
-
-    fn element(&self, index: [usize; 2]) -> FE {
-        self.get(index[0])
-            .and_then(|s| s.get(index[1]))
-            .cloned()
-            .unwrap_or(FE::ZERO)
-    }
-
-    fn bind(&self, binding: &[FE]) -> Self {
-        // Specification interpretation verification: we expect to be binding down to a single
-        // element, but no further.
-        assert!(
-            binding.is_empty() || self.len() > 1,
-            "binding over a dimension that's already reduced to a single element"
-        );
-
-        let mut bound = self.clone();
-        for binding_element in binding {
-            // The back half of B[i] will always be zero so we can skip computing those elements
-            let new_len = bound.len().div_ceil(2);
-            for index in 0..new_len {
-                // First term: (1 - x) * A[2 * i]
-                // Grab the 2i-th row, scale its elements by 1 - x
-                let first_term: Vec<_> = bound
-                    .get(2 * index)
-                    .unwrap_or(&Vec::new())
-                    .scale(FE::ONE - *binding_element);
-
-                // Second term: x * A[2 * i + 1]
-                // Grab the (2i + 1)th row, scale its elements by x
-                let second_term = bound
-                    .get(2 * index + 1)
-                    .unwrap_or(&Vec::new())
-                    .scale(*binding_element);
-
-                bound[index] = first_term.elementwise_sum(&second_term);
-            }
-
-            bound.truncate(new_len);
-        }
-
-        bound
-    }
-
-    fn bind_in_place(&mut self, binding: FE) {
-        // Specification interpretation verification: we expect to be binding down to a single
-        // element, but no further.
-        assert!(
-            self.len() > 1,
-            "binding over a dimension that's already reduced to a single element",
-        );
-
-        // B[i] = (1 - x) * A[2 * i] + x * A[2 * i + 1]
-        // The back half of B[i] will always be zero so we can skip computing those elements
-        let new_len = self.len().div_ceil(2);
-        for index in 0..new_len {
-            // First term: (1 - x) * A[2 * i]
-            // Grab the 2i-th row, scale its elements by 1 - x
-            let first_term: Vec<_> = self
-                .get(2 * index)
-                .unwrap_or(&Vec::new())
-                .scale(FE::ONE - binding);
-
-            // Second term: x * A[2 * i + 1]
-            // Grab the (2i + 1)th row, scale its elements by x
-            let second_term = self
-                .get(2 * index + 1)
-                .unwrap_or(&Vec::new())
-                .scale(binding);
-
-            self[index] = first_term.elementwise_sum(&second_term);
-        }
-
-        self.truncate(new_len);
-    }
-
-    fn scale(&self, scalar: FE) -> Self {
-        self.iter().map(|row| row.scale(scalar)).collect()
-    }
-
-    fn transpose(&self) -> Self {
-        // find biggest row so we can allocate appropriately
-        let mut biggest = 0;
-        for row in self {
-            if row.len() > biggest {
-                biggest = row.len();
-            }
-        }
-
-        let mut transposed = vec![vec![FE::ZERO; self.len()]; biggest];
-
-        for i in 0..self.len() {
-            #[allow(clippy::needless_range_loop)]
-            for j in 0..self[i].len() {
-                let element = self.element([i, j]);
-                transposed[j][i] = element;
-            }
-        }
-
-        transposed
-    }
-}
-
-impl<FE: FieldElement> SumcheckArray<FE> for Vec<Vec<Vec<FE>>> {
-    type Index = [usize; 3];
-
-    fn element(&self, index: [usize; 3]) -> FE {
-        self.get(index[0])
-            .and_then(|s| s.get(index[1]))
-            .and_then(|s| s.get(index[2]))
-            .cloned()
-            .unwrap_or(FE::ZERO)
-    }
-
-    fn bind(&self, binding: &[FE]) -> Self {
-        // Specification interpretation verification: we expect to be binding down to a single
-        // element, but no further.
-        assert!(
-            binding.is_empty() || self.len() > 1,
-            "binding over a dimension that's already reduced to a single element"
-        );
-
-        let mut bound = self.clone();
-        for binding_element in binding {
-            // The back half of B[i] is always zero so we can skip computing those elements.
-            let new_len = bound.len().div_ceil(2);
-            for index in 0..new_len {
-                // First term: (1 - x) * A[2 * i]
-                // Grab the 2i-th "row", scale its elements by 1 - x
-                let first_term: Vec<_> = bound
-                    .get(2 * index)
-                    .unwrap_or(&Vec::new())
-                    .iter()
-                    .map(|row| row.scale(FE::ONE - binding_element))
-                    .collect();
-
-                // Second term: x * A[2 * i + 1]
-                // Grab the (2i + 1)th "row", scale its elements by x
-                let second_term: Vec<_> = bound
-                    .get(2 * index + 1)
-                    .unwrap_or(&Vec::new())
-                    .iter()
-                    .map(|row| row.scale(*binding_element))
-                    .collect();
-
-                bound[index] = first_term.elementwise_sum(&second_term);
-            }
-
-            bound.truncate(new_len);
-        }
-
-        bound
-    }
-
-    fn bind_in_place(&mut self, binding: FE) {
-        // Specification interpretation verification: we expect to be binding down to a single
-        // element, but no further.
-        assert!(
-            self.len() > 1,
-            "binding over a dimension that's already reduced to a single element",
-        );
-
-        // B[i] = (1 - x) * A[2 * i] + x * A[2 * i + 1]
-        // The back half of B[i] will always be zero so we can skip computing those elements
-        let new_len = self.len().div_ceil(2);
-        for index in 0..new_len {
-            // First term: (1 - x) * A[2 * i]
-            // Grab the 2i-th "row", scale its elements by 1 - x
-            let first_term: Vec<_> = self
-                .get(2 * index)
-                .unwrap_or(&Vec::new())
-                .iter()
-                .map(|row| row.scale(FE::ONE - binding))
-                .collect();
-
-            // Second term: x * A[2 * i + 1]
-            // Grab the (2i + 1)th "row", scale its elements by x
-            let second_term: Vec<_> = self
-                .get(2 * index + 1)
-                .unwrap_or(&Vec::new())
-                .iter()
-                .map(|row| row.scale(binding))
-                .collect();
-
-            self[index] = first_term.elementwise_sum(&second_term);
-        }
-
-        self.truncate(new_len);
-    }
-
-    fn scale(&self, scalar: FE) -> Self {
-        self.iter().map(|array| array.scale(scalar)).collect()
-    }
-
-    fn transpose(&self) -> Self {
-        self.iter().map(Vec::transpose).collect()
-    }
-}
-
-/// Sum collections of things elementwise, applying the Sumcheck array convention where `A[i] = 0`
-/// if not defined.
+/// Compute `bindv(EQ, bindings_0) + scale * bindv(EQ, bindings_1)` using `bindv(EQ_{n}, X) =
+/// bindeq(l, X)` of [6.2][1].
 ///
-/// The more obvious thing would be to use `std::ops::Add` but we can't implement `Add` on `Vec` in
-/// this crate.
-pub trait ElementwiseSum: Sized + Default + Clone + PartialEq + Eq + std::fmt::Debug {
-    /// Sum with another instance.
-    fn elementwise_sum(&self, rhs: &Self) -> Self;
-}
-
-impl<T: ElementwiseSum> ElementwiseSum for Vec<T> {
-    fn elementwise_sum(&self, rhs: &Self) -> Self {
-        // Pad whichever of the two iterators is the shortest with default values, which in practice
-        // will be empty vectors or FieldElement::ZERO.
-        let default = T::default();
-        let chain = repeat(&default);
-
-        let (lhs, rhs) = if self.len() > rhs.len() {
-            (self.iter(), rhs.iter().chain(chain))
-        } else {
-            // Flip the order of the iterators so that either arm evaluates to the same type
-            (rhs.iter(), self.iter().chain(chain))
-        };
-
-        lhs.zip(rhs)
-            .map(|(lhs, rhs)| lhs.elementwise_sum(rhs))
-            .collect::<Vec<_>>()
+/// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-6.2
+pub fn bindeq<FE: FieldElement>(bindings_0: &[FE], bindings_1: &[FE], scale: FE) -> Vec<FE> {
+    let mut bindeq_0 = bindeq_inner(bindings_0);
+    for (bindeq_0, bindeq_1) in bindeq_0.iter_mut().zip(bindeq_inner(bindings_1).iter()) {
+        *bindeq_0 += scale * bindeq_1;
     }
-}
-
-impl<FE: FieldElement> ElementwiseSum for FE {
-    fn elementwise_sum(&self, rhs: &Self) -> Self {
-        *self + *rhs
-    }
+    bindeq_0
 }
 
 /// Naive implementation of bindeq() from 6.2 ([1]). This binds `input` of length `l` to the
@@ -350,14 +71,14 @@ impl<FE: FieldElement> ElementwiseSum for FE {
 ///
 /// [1]: https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-01#section-6.2
 /// [2]: https://github.com/abetterinternet/zk-cred-longfellow/issues/41
-pub fn bindeq<FE: FieldElement>(input: &[FE]) -> Vec<FE> {
+fn bindeq_inner<FE: FieldElement>(input: &[FE]) -> Vec<FE> {
     let output_len = 1 << input.len();
     let mut bound = vec![FE::ZERO; output_len];
 
     if input.is_empty() {
         bound[0] = FE::ONE;
     } else {
-        let a = bindeq(&input[1..]);
+        let a = bindeq_inner(&input[1..]);
         // usize::div rounds towards zero
         for index in 0..output_len / 2 {
             bound[2 * index] = (FE::ONE - input[0]) * a[index];
@@ -374,7 +95,8 @@ pub(crate) mod tests {
         field_element_tests,
         fields::{CodecFieldElement, FieldElement},
         sumcheck::bind::{
-            SumcheckArray, bindeq,
+            DenseSumcheckArray, bindeq_inner,
+            sparse::{Hand, SparseSumcheckArray},
             test_vector::{
                 BindTestVector, Dense1DArrayBindTestCase, load_dense_1d_array_bind_2_128,
                 load_dense_1d_array_bind_p128, load_dense_1d_array_bind_p256,
@@ -384,17 +106,13 @@ pub(crate) mod tests {
     use std::iter::Iterator;
     use wasm_bindgen_test::wasm_bindgen_test;
 
-    pub(crate) fn field_vec<FE: FieldElement>(values: &[u128]) -> Vec<FE> {
-        values.iter().map(|v| FE::from_u128(*v)).collect()
-    }
-
     fn dense_1d_array_bind_test_vector<FE: CodecFieldElement>(
         test_vector: BindTestVector<Dense1DArrayBindTestCase<FE>>,
     ) {
-        for test_case in test_vector.test_cases {
-            let bound = test_case.input.bind(&[test_case.binding]);
+        for mut test_case in test_vector.test_cases {
+            test_case.input.bind(test_case.binding);
             assert_eq!(
-                bound, test_case.output,
+                test_case.input, test_case.output,
                 "test case {} failed",
                 test_case.description
             );
@@ -415,445 +133,6 @@ pub(crate) mod tests {
     fn dense_1d_array_bind_test_vector_2_128() {
         dense_1d_array_bind_test_vector(load_dense_1d_array_bind_2_128())
     }
-
-    fn one_dimension_bindv<FE: FieldElement>() {
-        // Bind to multiple field elements, described as bindv in the spec
-        let original = field_vec::<FE>(&(0..100).collect::<Vec<_>>());
-        let two = FE::from_u128(2);
-        let bound = original.bind(&[FE::ONE, two]);
-
-        // Expand bindv(A, [x0, x1])[i] to
-        // (1 - x1) * ((1 - x0) * A[4i] + x0 * A[4i + 1])
-        //     + x1 * ((1 - x0) * A[4i + 2] + x0 * A[4i + 3])
-        // Plugging in x0 = 1, x1 = 2, but noting that 1 - 2 = -1 is not true in all fields:
-        // bind(A, [1, 2])[i] = (1 - 2) * A[4i + 1] + 2 * A[4i + 3]
-        for index in 0..original.len() {
-            assert_eq!(
-                bound.element(index),
-                (FE::ONE - two) * original.element(4 * index + 1)
-                    + two * original.element(4 * index + 3),
-                "mismatch at index {index}: bound({}): {bound:#?}",
-                bound.len(),
-            );
-        }
-    }
-
-    field_element_tests!(one_dimension_bindv);
-
-    fn two_dimension_bind_one<FE: FieldElement>() {
-        let mut original = vec![
-            field_vec::<FE>(&[0, 5, 10, 15, 20]),
-            field_vec::<FE>(&[1, 6, 11, 16, 21]),
-            field_vec::<FE>(&[2, 7, 12, 17, 22]),
-            field_vec::<FE>(&[3, 8, 13, 18, 23]),
-            field_vec::<FE>(&[4, 9, 14, 19, 24]),
-        ];
-
-        let bound = original.bind(&[FE::ONE]);
-
-        // Accessing row 0 of the bound array should access row 1 of the underlying array, but the
-        // column access is unaffected.
-        assert_eq!(bound.element([0, 0]), FE::from_u128(1));
-        assert_eq!(bound.element([0, 1]), FE::from_u128(6));
-        // Accessing row 1 of the bound array should access row 3 of the underlying array.
-        assert_eq!(bound.element([1, 2]), FE::from_u128(13));
-        assert_eq!(bound.element([1, 4]), FE::from_u128(23));
-
-        // Values from further rows should be 0, including indices outside the array.
-        for i in 2..(original.len() + 1) {
-            assert_eq!(bound.element([i, i]), FE::ZERO);
-        }
-
-        // Check that binding in place is equivalent
-        original.bind_in_place(FE::ONE);
-        assert_eq!(bound, original);
-    }
-
-    field_element_tests!(two_dimension_bind_one);
-
-    fn two_dimension_bind_zero<FE: FieldElement>() {
-        let mut original = vec![
-            field_vec::<FE>(&[0, 5, 10, 15, 20]),
-            field_vec::<FE>(&[1, 6, 11, 16, 21]),
-            field_vec::<FE>(&[2, 7, 12, 17, 22]),
-            field_vec::<FE>(&[3, 8, 13, 18, 23]),
-            field_vec::<FE>(&[4, 9, 14, 19, 24]),
-        ];
-
-        let bound = original.bind(&[FE::ZERO]);
-        assert_eq!(bound.element([2, 2]), FE::from_u128(14));
-
-        // Check that binding in place is equivalent
-        original.bind_in_place(FE::ZERO);
-        assert_eq!(bound, original);
-    }
-
-    field_element_tests!(two_dimension_bind_zero);
-
-    fn two_dimension_bindv<FE: FieldElement>() {
-        let original = vec![
-            field_vec::<FE>(&[0; 5]),
-            field_vec(&[1; 5]),
-            field_vec(&[2; 5]),
-            field_vec(&[3; 5]),
-            field_vec(&[4; 5]),
-            field_vec(&[5; 5]),
-            field_vec(&[6; 5]),
-            field_vec(&[7; 5]),
-            field_vec(&[8; 5]),
-            field_vec(&[9; 5]),
-            field_vec(&[10; 5]),
-            field_vec(&[11; 5]),
-            field_vec(&[12; 5]),
-            field_vec(&[13; 5]),
-            field_vec(&[14; 5]),
-        ];
-
-        let two = FE::from_u128(2);
-        let one_minus_two = FE::ONE - two;
-        let bound = original.bind(&[FE::ONE, FE::from_u128(2)]);
-
-        // Expand bindv(A, [x0, x1])[i] to
-        // (1 - x1) * ((1 - x0) * A[4i] + x0 * A[4i + 1])
-        //     + x1 * ((1 - x0) * A[4i + 2] + x0 * A[4i + 3])
-        // Plugging in x0 = 1, x1 = 2, but noting that 1 - 2 = -1 is not true in all fields:
-        // bind(A, [1, 2])[i] = (1 - 2) * A[4i + 1] + 2 * A[4i + 3]
-        // Row 0 of the bound array should be (1 - 2) * row 1 + 2 * row 3 (elementwise)
-        for i in 0..original[0].len() {
-            assert_eq!(
-                bound.element([0, i]),
-                one_minus_two * FE::ONE + two * FE::from_u128(3),
-            );
-        }
-
-        // Row 1 of the bound array should be (1 - 2) * row 5 + 2 * row 7 (elementwise)
-        for i in 0..original[1].len() {
-            assert_eq!(
-                bound.element([1, i]),
-                one_minus_two * FE::from_u128(5) + two * FE::from_u128(7),
-            );
-        }
-
-        // Row 2 of the bound array should be (1 - 2) * row 9 + 2 * row 11 (elementwise)
-        for i in 0..original[2].len() {
-            assert_eq!(
-                bound.element([2, i]),
-                one_minus_two * FE::from_u128(9) + two * FE::from_u128(11),
-            );
-        }
-
-        // Row 3 of the bound array should be (1 - 2) * row 13 + 2 * row 15 (0) (elementwise)
-        for i in 0..original[3].len() {
-            assert_eq!(bound.element([3, i]), one_minus_two * FE::from_u128(13));
-        }
-
-        // All other values in the bound array should be 0
-        #[allow(clippy::needless_range_loop)]
-        for i in 4..original.len() {
-            for j in 0..original[i].len() {
-                assert_eq!(bound.element([i, j]), FE::ZERO);
-            }
-        }
-    }
-
-    field_element_tests!(two_dimension_bindv);
-
-    fn three_dimension_bind_one<FE: FieldElement>() {
-        let mut original = vec![
-            vec![field_vec(&[0; 5]); 2],
-            vec![field_vec(&[1; 5]); 2],
-            vec![field_vec(&[2; 5]); 2],
-            vec![field_vec(&[3; 5]); 2],
-            vec![field_vec(&[4; 5]); 2],
-        ];
-
-        let bound = original.bind(&[FE::ONE]);
-
-        // "Row" 0 (which is an array) should be row 1
-        assert_eq!(bound[0], vec![field_vec(&[1; 5]); 2]);
-
-        // "Row" 1 should be row 3
-        assert_eq!(bound[1], vec![field_vec(&[3; 5]); 2]);
-
-        // All other values should be 0
-        #[allow(clippy::needless_range_loop)]
-        for i in 2..original.len() {
-            for j in 0..original[i].len() {
-                for k in 0..original[i][j].len() {
-                    assert_eq!(bound.element([i, j, k]), FE::ZERO);
-                }
-            }
-        }
-
-        // Indices outside the array should be zero
-        assert_eq!(bound.element([original.len(), 0, 0]), FE::ZERO);
-
-        // Check that binding in place is equivalent
-        original.bind_in_place(FE::ONE);
-        assert_eq!(bound, original);
-    }
-
-    field_element_tests!(three_dimension_bind_one);
-
-    fn three_dimension_bindv<FE: crate::fields::CodecFieldElement>() {
-        let original = vec![
-            vec![field_vec(&[0; 5]); 2],
-            vec![field_vec(&[1; 5]); 2],
-            vec![field_vec(&[2; 5]); 2],
-            vec![field_vec(&[3; 5]); 2],
-            vec![field_vec(&[4; 5]); 2],
-            vec![field_vec(&[5; 5]); 2],
-            vec![field_vec(&[6; 5]); 2],
-            vec![field_vec(&[7; 5]); 2],
-            vec![field_vec(&[8; 5]); 2],
-            vec![field_vec(&[9; 5]); 2],
-            vec![field_vec(&[10; 5]); 2],
-            vec![field_vec(&[11; 5]); 2],
-            vec![field_vec(&[12; 5]); 2],
-            vec![field_vec(&[13; 5]); 2],
-            vec![field_vec(&[14; 5]); 2],
-        ];
-
-        let two = FE::from_u128(2);
-        let one_minus_two = FE::ONE - two;
-        let bound = original.bind(&[FE::ONE, two]);
-
-        // "Row" 0 (which is an array) should be (1 - 2) * row 1 + 2 * row 3 (elementwise)
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..original[0].len() {
-            for j in 0..original[0][i].len() {
-                assert_eq!(
-                    bound.element([0, i, j]),
-                    one_minus_two * FE::ONE + two * FE::from_u128(3),
-                );
-            }
-        }
-
-        // "Row" 1 should be (1 - 2) * row 5 + 2 * row 7 (elementwise)
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..original[1].len() {
-            for j in 0..original[1][i].len() {
-                assert_eq!(
-                    bound.element([1, i, j]),
-                    one_minus_two * FE::from_u128(5) + two * FE::from_u128(7),
-                );
-            }
-        }
-
-        // "Row" 2 should be (1 - 2) * row 9 + 2 * row 11 (elementwise)
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..original[2].len() {
-            for j in 0..original[2][i].len() {
-                assert_eq!(
-                    bound.element([2, i, j]),
-                    one_minus_two * FE::from_u128(9) + two * FE::from_u128(11),
-                );
-            }
-        }
-
-        // "Row" 3 of the bound array should be (1 - 2) * row 13 + 2 * row 15 (0) (elementwise)
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..original[3].len() {
-            for j in 0..original[3][i].len() {
-                assert_eq!(bound.element([3, i, j]), one_minus_two * FE::from_u128(13));
-            }
-        }
-
-        // All other values should be 0
-        #[allow(clippy::needless_range_loop)]
-        for i in 4..original.len() {
-            for j in 0..original[i].len() {
-                for k in 0..original[i][j].len() {
-                    assert_eq!(bound.element([i, j, k]), FE::ZERO);
-                }
-            }
-        }
-    }
-
-    field_element_tests!(three_dimension_bindv);
-
-    fn transpose_2d<FE: FieldElement>() {
-        let original = vec![
-            field_vec::<FE>(&[0, 5, 10, 15, 20]),
-            field_vec::<FE>(&[1, 6, 11, 16, 21]),
-            field_vec::<FE>(&[2, 7, 12, 17, 22]),
-            field_vec::<FE>(&[3, 8, 13, 18, 23]),
-            field_vec::<FE>(&[4, 9, 14, 19, 24]),
-        ];
-
-        let transposed = original.transpose();
-
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..original.len() {
-            for j in 0..original[i].len() {
-                assert_eq!(transposed[i][j], original[j][i]);
-            }
-        }
-
-        let transposed = transposed.transpose();
-
-        for i in 0..original.len() {
-            for j in 0..original[i].len() {
-                assert_eq!(transposed[i][j], original[i][j]);
-            }
-        }
-
-        let bound_array = original.bind(&[FE::from_u128(2), FE::from_u128(3)]);
-        let transposed_bound_array = bound_array.transpose();
-
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..original.len() {
-            for j in 0..original[i].len() {
-                assert_eq!(
-                    bound_array.element([i, j]),
-                    transposed_bound_array.element([j, i])
-                );
-            }
-        }
-
-        let transposed_bound_array = transposed_bound_array.transpose();
-
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..original.len() {
-            for j in 0..original[i].len() {
-                assert_eq!(
-                    bound_array.element([i, j]),
-                    transposed_bound_array.element([i, j])
-                );
-            }
-        }
-    }
-
-    field_element_tests!(transpose_2d);
-
-    fn transpose_3d<FE: FieldElement>() {
-        // Transposing a 3d array should only affect the last two dimensions
-        let original = vec![vec![
-            field_vec::<FE>(&[0, 5, 10, 15, 20]),
-            field_vec::<FE>(&[1, 6, 11, 16, 21]),
-            field_vec::<FE>(&[2, 7, 12, 17, 22]),
-            field_vec::<FE>(&[3, 8, 13, 18, 23]),
-            field_vec::<FE>(&[4, 9, 14, 19, 24]),
-        ]];
-
-        let transposed = original.transpose();
-
-        for i in 0..original.len() {
-            for j in 0..original[i].len() {
-                assert_eq!(transposed[0][i][j], original[0][j][i]);
-            }
-        }
-
-        let transposed = transposed.transpose();
-
-        for i in 0..original.len() {
-            for j in 0..original[i].len() {
-                assert_eq!(transposed[0][i][j], original[0][i][j]);
-            }
-        }
-    }
-
-    field_element_tests!(transpose_3d);
-
-    fn scalar_mul_1d<FE: FieldElement>() {
-        let two = FE::from_u128(2);
-        let three = FE::from_u128(3);
-        let original = field_vec::<FE>(&[1, 2, 3, 4, 5]);
-
-        let scaled = original.scale(two);
-        assert_eq!(
-            scaled,
-            vec![
-                FE::from_u128(1) * two,
-                FE::from_u128(2) * two,
-                FE::from_u128(3) * two,
-                FE::from_u128(4) * two,
-                FE::from_u128(5) * two,
-            ]
-        );
-
-        let scaled_again = scaled.scale(three);
-        assert_eq!(
-            scaled_again,
-            vec![
-                FE::from_u128(1) * two * three,
-                FE::from_u128(2) * two * three,
-                FE::from_u128(3) * two * three,
-                FE::from_u128(4) * two * three,
-                FE::from_u128(5) * two * three,
-            ]
-        );
-    }
-
-    field_element_tests!(scalar_mul_1d);
-
-    fn scalar_mul_2d<FE: FieldElement>() {
-        let two = FE::from_u128(2);
-        let three = FE::from_u128(3);
-        let original = vec![
-            field_vec::<FE>(&[1, 2, 3, 4, 5]),
-            field_vec(&[1, 2, 3, 4, 5]),
-        ];
-
-        let scaled = original.scale(two);
-        assert_eq!(
-            scaled,
-            vec![
-                vec![
-                    FE::from_u128(1) * two,
-                    FE::from_u128(2) * two,
-                    FE::from_u128(3) * two,
-                    FE::from_u128(4) * two,
-                    FE::from_u128(5) * two,
-                ];
-                2
-            ],
-        );
-
-        let scaled_again = scaled.scale(three);
-        assert_eq!(
-            scaled_again,
-            vec![
-                vec![
-                    FE::from_u128(1) * two * three,
-                    FE::from_u128(2) * two * three,
-                    FE::from_u128(3) * two * three,
-                    FE::from_u128(4) * two * three,
-                    FE::from_u128(5) * two * three,
-                ];
-                2
-            ],
-        );
-    }
-
-    field_element_tests!(scalar_mul_2d);
-
-    fn scalar_mul_3d<FE: FieldElement>() {
-        let original = vec![
-            vec![field_vec::<FE>(&[0; 5]); 2],
-            vec![field_vec(&[1; 5]); 2],
-        ];
-
-        let scaled = original.scale(FE::from_u128(2));
-        assert_eq!(
-            scaled,
-            vec![
-                vec![field_vec::<FE>(&[0; 5]); 2],
-                vec![field_vec(&[2; 5]); 2],
-            ],
-        );
-
-        let scaled_again = scaled.scale(FE::from_u128(3));
-        assert_eq!(
-            scaled_again,
-            vec![
-                vec![field_vec::<FE>(&[0; 5]); 2],
-                vec![field_vec(&[6; 5]); 2],
-            ],
-        );
-    }
-
-    field_element_tests!(scalar_mul_3d);
 
     fn bindeq_equivalence<FE: FieldElement>() {
         // 6.2: bindv(EQ_{n}, X) = bindeq(l, X) for n = 2^l
@@ -877,7 +156,29 @@ pub(crate) mod tests {
                 construct_eq(4),
             ),
         ] {
-            assert_eq!(bindeq(binding.as_slice()), eq_n.bind(binding.as_slice())[0]);
+            let mut sparse = <SparseSumcheckArray<FE> as From<Vec<Vec<FE>>>>::from(eq_n);
+            for binding_element in &binding {
+                sparse.bind_hand(Hand::Left, *binding_element);
+            }
+            for element in sparse.contents() {
+                assert_eq!(element.gate_index, 0);
+                assert_eq!(element.left_wire_index, 0);
+            }
+
+            for (index, element) in bindeq_inner(&binding).iter().enumerate() {
+                let mut saw_element = false;
+                for sparse_element in sparse.contents() {
+                    if sparse_element.right_wire_index == index {
+                        assert_eq!(sparse_element.coefficient, *element);
+                        saw_element = true;
+                    }
+                }
+                if *element == FE::ZERO {
+                    assert!(!saw_element)
+                } else {
+                    assert!(saw_element);
+                }
+            }
         }
     }
 

--- a/src/sumcheck/bind/test_vector.rs
+++ b/src/sumcheck/bind/test_vector.rs
@@ -5,7 +5,7 @@ use crate::{
         CodecFieldElement, field2_128::Field2_128, fieldp128::FieldP128, fieldp256::FieldP256,
     },
     sumcheck::bind::{
-        SumcheckArray,
+        DenseSumcheckArray,
         sparse::{Hand, SparseSumcheckArray},
     },
 };
@@ -185,9 +185,10 @@ fn generate_1d_dense_array_bind_test_vector_with_seed<FE: CodecFieldElement>(
         (11, "length odd"),
         (16, "length power of 2"),
     ] {
-        let input = rng.sample_n(input_len, 0.0);
+        let mut output = rng.sample_n(input_len, 0.0);
+        let input = output.clone();
         let binding: FE = rng.sample(0.0);
-        let output = input.bind(&[binding]);
+        output.bind(binding);
         test_cases.push(Dense1DArrayBindTestCase {
             description: description.to_string(),
             input,

--- a/src/zk_one_circuit.rs
+++ b/src/zk_one_circuit.rs
@@ -41,7 +41,6 @@ mod tests {
         test_vector_end_to_end::<FieldP128>(test_vector, circuit);
     }
 
-    #[ignore = "slow test"]
     #[wasm_bindgen_test(unsupported = test)]
     fn longfellow_mac_circuit_end_to_end() {
         let (test_vector, circuit) = load_mac();


### PR DESCRIPTION
Now that we have proven that the sparse sumcheck array is equivalent to the dense one, we can cut over to it completely. This significantly speeds up sumcheck proving and constraint generation, so we can un-ignore tests on the MAC circuit.

It also means we can delete much of `sumcheck::bind`: the implementations of `SumcheckArray` (now renamed `DenseSumcheckArray` for better contrast with `SparseSumcheckArray`) on `Vec<Vec<FE>>` and `Vec<Vec<Vec<FE>>>` are not used any more, so we can delete then, and it turns out all we need from the 1D implementation is in place binding.

Part of #100