### PR TITLE
Add `ParameterizedCodec` and adopt it

### DIFF
--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -356,7 +356,7 @@ pub use ntt::NttFieldElement;
 #[cfg(test)]
 mod tests {
     use crate::{
-        Codec,
+        Codec, ParameterizedCodec,
         fields::{
             CodecFieldElement, FieldElement, ProofFieldElement, field2_128::Field2_128,
             fieldp128::FieldP128, fieldp256::FieldP256, fieldp256_2::FieldP256_2,
@@ -446,17 +446,17 @@ mod tests {
 
     #[wasm_bindgen_test(unsupported = test)]
     fn field_p256_roundtrip() {
-        FieldP256::from_u128(111).roundtrip();
+        FieldP256::from_u128(111).roundtrip(&());
     }
 
     #[wasm_bindgen_test(unsupported = test)]
     fn field_p128_roundtrip() {
-        FieldP128::from_u128(111).roundtrip();
+        FieldP128::from_u128(111).roundtrip(&());
     }
 
     #[wasm_bindgen_test(unsupported = test)]
     fn field_2_128_roundtrip() {
-        Field2_128::from_u128(0xdeadbeef12345678f00faaaabbbbcccc).roundtrip();
+        Field2_128::from_u128(0xdeadbeef12345678f00faaaabbbbcccc).roundtrip(&());
     }
 
     /// Test methods of [`FieldElement`] implementations.

--- a/src/ligero/merkle.rs
+++ b/src/ligero/merkle.rs
@@ -290,6 +290,7 @@ impl MerkleTree {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ParameterizedCodec;
     use wasm_bindgen_test::wasm_bindgen_test;
 
     fn simple_tree() -> MerkleTree {
@@ -491,7 +492,7 @@ mod tests {
             Node::from(Sha256Digest([3; 32])),
             Node::from(Sha256Digest([4; 32])),
         ])
-        .roundtrip();
+        .roundtrip(&());
     }
 
     #[wasm_bindgen_test(unsupported = test)]

--- a/src/test_vector.rs
+++ b/src/test_vector.rs
@@ -1,7 +1,7 @@
 //! Test vectors for the Longfellow protocol.
 
 use crate::{
-    Codec,
+    Codec, ParameterizedCodec,
     circuit::Circuit,
     constraints::proof_constraints::QuadraticConstraint,
     fields::{CodecFieldElement, field2_128::Field2_128, fieldp128::FieldP128},
@@ -162,14 +162,10 @@ impl<FE: CodecFieldElement> CircuitTestVector<FE> {
     }
 
     pub(crate) fn sumcheck_proof(&self, circuit: &Circuit<FE>) -> SumcheckProof<FE> {
-        SumcheckProof::decode(circuit, &mut Cursor::new(&self.serialized_sumcheck_proof)).unwrap()
+        SumcheckProof::get_decoded_with_param(circuit, &self.serialized_sumcheck_proof).unwrap()
     }
 
     pub(crate) fn ligero_proof(&self, tableau_layout: &TableauLayout) -> LigeroProof<FE> {
-        LigeroProof::decode(
-            tableau_layout,
-            &mut Cursor::new(&self.serialized_ligero_proof),
-        )
-        .unwrap()
+        LigeroProof::get_decoded_with_param(tableau_layout, &self.serialized_ligero_proof).unwrap()
     }
 }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -56,6 +56,7 @@ impl Transcript {
     ///
     /// The specification is not clear about what `session_id` is, but in the C++ implementation,
     /// it's an opaque byte buffer ([1]).
+    /// Initialize a transcript with the session ID, which is the SHA-256 digest of the circuit.
     ///
     /// <https://datatracker.ietf.org/doc/html/draft-google-cfrg-libzk-00#section-3.1.1>
     ///

--- a/src/zk_one_circuit/verifier.rs
+++ b/src/zk_one_circuit/verifier.rs
@@ -32,6 +32,15 @@ impl<'a, FE: ProofFieldElement> Verifier<'a, FE> {
         }
     }
 
+    /// Construct the Ligero tableau layout.
+    pub fn tableau_layout(&self) -> TableauLayout<'_> {
+        TableauLayout::new(
+            &self.ligero_parameters,
+            self.witness_length,
+            self.quadratic_constraints.len(),
+        )
+    }
+
     /// Verify a Longfellow ZK proof.
     pub fn verify(&self, statement: &[FE], proof: &Proof<FE>) -> Result<(), anyhow::Error>
     where
@@ -41,13 +50,6 @@ impl<'a, FE: ProofFieldElement> Verifier<'a, FE> {
         let mut inputs = Vec::with_capacity(statement.len() + 1);
         inputs.push(FE::ONE);
         inputs.extend(statement);
-
-        // Construct tableau layout struct.
-        let tableau_layout = TableauLayout::new(
-            &self.ligero_parameters,
-            self.witness_length,
-            self.quadratic_constraints.len(),
-        );
 
         // Start of Fiat-Shamir transcript.
         let mut transcript = Transcript::new(proof.oracle()).unwrap();
@@ -70,7 +72,7 @@ impl<'a, FE: ProofFieldElement> Verifier<'a, FE> {
             &mut transcript,
             &linear_constraints,
             &self.quadratic_constraints,
-            &tableau_layout,
+            &self.tableau_layout(),
         )?;
 
         Ok(())


### PR DESCRIPTION
Several types throughout the crate need some context to be encoded or decoded and thus could implement trait `Codec`. We define a new `ParameterizedCodec`, cribbed from `prio::codec`. Using this lets us avoid some `Cursor` and `Vec` ceremony in a variety of places.

- `circuit::Quad`
- `ligero::prover::LigeroProof`
- `sumcheck::prover::SumcheckProof`
- `zk_one_circuit::prover::Proof`