### PR TITLE
Use protected field parsed from COSE_Sign1

### DIFF
--- a/src/mdoc_zk/mdoc/cose.rs
+++ b/src/mdoc_zk/mdoc/cose.rs
@@ -16,7 +16,6 @@ pub(super) struct CoseSign1 {
     ///
     /// If there are no protected header parameters, this will be the empty byte string. Otherwise,
     /// it will be the CBOR encoding of a map.
-    #[allow(unused)]
     pub(super) protected: Vec<u8>,
     /// Unprotected header parameters.
     pub(super) unprotected: CoseUnprotectedHeaders,


### PR DESCRIPTION
This makes use of the parsed `protected` field from the issuer's signature, instead of hardcoding the expected algorithm header. As a result, we can get rid of the last unnecessary `#[allow(unused)]`, and close #124.