### PR TITLE
Print git revision at start of benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1191,7 @@ dependencies = [
  "crypto-common",
  "educe",
  "getrandom",
+ "git-version",
  "hex",
  "num-bigint",
  "num-integer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ criterion = { version = "0.8.0", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
+git-version = "0.3.9"
 hex = { version = "0.4.3", features = ["serde"] }
 num-traits = "0.2.19"
 pretty_assertions = "1.4.1"

--- a/benches/extend.rs
+++ b/benches/extend.rs
@@ -1,6 +1,4 @@
-use criterion::{
-    BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main, measurement::WallTime,
-};
+use criterion::{BenchmarkGroup, BenchmarkId, Criterion, criterion_group, measurement::WallTime};
 use std::{hint::black_box, time::Duration};
 use zk_cred_longfellow::fields::{
     ProofFieldElement, field2_128::Field2_128, fieldp128::FieldP128, fieldp256::FieldP256,
@@ -76,4 +74,12 @@ fn benchmark_all(c: &mut Criterion) {
 }
 
 criterion_group!(benches, benchmark_all);
-criterion_main!(benches);
+
+fn main() {
+    let git_version = git_version::git_version!(fallback = "unknown");
+    println!("Git revision: {git_version}");
+    println!();
+
+    benches();
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/benches/field.rs
+++ b/benches/field.rs
@@ -1,6 +1,4 @@
-use criterion::{
-    BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
-};
+use criterion::{BenchmarkGroup, Criterion, criterion_group, measurement::WallTime};
 use std::hint::black_box;
 use zk_cred_longfellow::fields::{
     FieldElement, field2_128::Field2_128, fieldp128::FieldP128, fieldp256::FieldP256,
@@ -50,4 +48,12 @@ fn benchmark_all_fields(c: &mut Criterion) {
 }
 
 criterion_group!(benches, benchmark_all_fields);
-criterion_main!(benches);
+
+fn main() {
+    let git_version = git_version::git_version!(fallback = "unknown");
+    println!("Git revision: {git_version}");
+    println!();
+
+    benches();
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/benches/longfellow_one_field.rs
+++ b/benches/longfellow_one_field.rs
@@ -1,4 +1,4 @@
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group};
 use std::{hint::black_box, io::Cursor};
 use zk_cred_longfellow::{
     Codec,
@@ -105,4 +105,12 @@ fn mac(c: &mut Criterion) {
 }
 
 criterion_group!(benches, rfc_1, mac);
-criterion_main!(benches);
+
+fn main() {
+    let git_version = git_version::git_version!(fallback = "unknown");
+    println!("Git revision: {git_version}");
+    println!();
+
+    benches();
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/benches/mdoc_zk.rs
+++ b/benches/mdoc_zk.rs
@@ -1,4 +1,4 @@
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group};
 use serde_json::Value;
 use std::{hint::black_box, time::Duration};
 use zk_cred_longfellow::mdoc_zk::{
@@ -84,4 +84,12 @@ criterion_group! {
     config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(180));
     targets = prove, verify
 }
-criterion_main!(benches);
+
+fn main() {
+    let git_version = git_version::git_version!(fallback = "unknown");
+    println!("Git revision: {git_version}");
+    println!();
+
+    benches();
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/benches/ntt.rs
+++ b/benches/ntt.rs
@@ -1,6 +1,4 @@
-use criterion::{
-    BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main, measurement::WallTime,
-};
+use criterion::{BenchmarkGroup, BenchmarkId, Criterion, criterion_group, measurement::WallTime};
 use std::hint::black_box;
 use zk_cred_longfellow::fields::{NttFieldElement, fieldp128::FieldP128, fieldp256_2::FieldP256_2};
 
@@ -28,4 +26,12 @@ fn benchmark_ntt_fields(c: &mut Criterion) {
 }
 
 criterion_group!(benches, benchmark_ntt_fields);
-criterion_main!(benches);
+
+fn main() {
+    let git_version = git_version::git_version!(fallback = "unknown");
+    println!("Git revision: {git_version}");
+    println!();
+
+    benches();
+    Criterion::default().configure_from_args().final_summary();
+}


### PR DESCRIPTION
This captures the output of `git describe` with a proc macro, and then prints it at the start of benchmark runs. This will make comparing benchmark results more foolproof, especially when running them in the browser with #164.