### PR TITLE
Add one more round of Karatsuba multiplication to fallback GF(2^128) implementation

### DIFF
--- a/src/fields/field2_128/backend_bit_slicing.rs
+++ b/src/fields/field2_128/backend_bit_slicing.rs
@@ -72,38 +72,52 @@ fn reduce(product: U256) -> u128 {
         ^ (first_reduction.high << 7)
 }
 
-const MASK_0: u128 = 0x21084210842108421084210842108421;
-const MASK_1: u128 = 0x42108421084210842108421084210842;
-const MASK_2: u128 = 0x84210842108421084210842108421084;
-const MASK_3: u128 = 0x08421084210842108421084210842108;
-const MASK_4: u128 = 0x10842108421084210842108421084210;
-
 /// Carryless multiplication of two 64-bit arguments.
 fn clmul64(x: u64, y: u64) -> u128 {
+    // This multiplication is decomposed into three smaller operations via Karatsuba multiplication.
+    let x_lo = x as u32;
+    let x_hi = (x >> 32) as u32;
+    let y_lo = y as u32;
+    let y_hi = (y >> 32) as u32;
+
+    let r1 = clmul32(x_lo, y_lo);
+    let r4 = clmul32(x_hi, y_hi);
+    let p_prime = x_lo ^ x_hi;
+    let q_prime = y_lo ^ y_hi;
+    let s = clmul32(p_prime, q_prime);
+    let t = s ^ r1 ^ r4;
+
+    let result_low = r1 ^ (t << 32);
+    let result_high = (t >> 32) ^ r4;
+    result_low as u128 | ((result_high as u128) << 64)
+}
+
+/// Carryless multiplication of two 32-bit arguments.
+fn clmul32(x: u32, y: u32) -> u64 {
     // This uses the technique outlined in
     // https://timtaubert.de/blog/2017/06/verified-binary-multiplication-for-ghash/. Integer
     // multiplications on masked arguments are used to build up a carryless multiplication. All bits
-    // except every fifth are masked off, so that the carries that accumulate during one integer
-    // multiply won't interfere with the LSB of the next group of five bits in the integer product.
+    // except every fourth are masked off, so that the carries that accumulate during one integer
+    // multiply won't interfere with the LSB of the next group of four bits in the integer product.
 
-    let x0 = (x & (MASK_0 as u64)) as u128;
-    let x1 = (x & (MASK_1 as u64)) as u128;
-    let x2 = (x & (MASK_2 as u64)) as u128;
-    let x3 = (x & (MASK_3 as u64)) as u128;
-    let x4 = (x & (MASK_4 as u64)) as u128;
-    let y0 = (y & (MASK_0 as u64)) as u128;
-    let y1 = (y & (MASK_1 as u64)) as u128;
-    let y2 = (y & (MASK_2 as u64)) as u128;
-    let y3 = (y & (MASK_3 as u64)) as u128;
-    let y4 = (y & (MASK_4 as u64)) as u128;
+    const MASK_0: u64 = 0x1111_1111_1111_1111;
+    const MASK_1: u64 = 0x2222_2222_2222_2222;
+    const MASK_2: u64 = 0x4444_4444_4444_4444;
+    const MASK_3: u64 = 0x8888_8888_8888_8888;
 
-    let z0 = ((x0 * y0) ^ (x1 * y4) ^ (x2 * y3) ^ (x3 * y2) ^ (x4 * y1)) & MASK_0;
-    let z1 = ((x0 * y1) ^ (x1 * y0) ^ (x2 * y4) ^ (x3 * y3) ^ (x4 * y2)) & MASK_1;
-    let z2 = ((x0 * y2) ^ (x1 * y1) ^ (x2 * y0) ^ (x3 * y4) ^ (x4 * y3)) & MASK_2;
-    let z3 = ((x0 * y3) ^ (x1 * y2) ^ (x2 * y1) ^ (x3 * y0) ^ (x4 * y4)) & MASK_3;
-    let z4 = ((x0 * y4) ^ (x1 * y3) ^ (x2 * y2) ^ (x3 * y1) ^ (x4 * y0)) & MASK_4;
-
-    z0 | z1 | z2 | z3 | z4
+    let x0 = (x & (MASK_0 as u32)) as u64;
+    let x1 = (x & (MASK_1 as u32)) as u64;
+    let x2 = (x & (MASK_2 as u32)) as u64;
+    let x3 = (x & (MASK_3 as u32)) as u64;
+    let y0 = (y & (MASK_0 as u32)) as u64;
+    let y1 = (y & (MASK_1 as u32)) as u64;
+    let y2 = (y & (MASK_2 as u32)) as u64;
+    let y3 = (y & (MASK_3 as u32)) as u64;
+    let z0 = ((x0 * y0) ^ (x1 * y3) ^ (x2 * y2) ^ (x3 * y1)) & MASK_0;
+    let z1 = ((x0 * y1) ^ (x1 * y0) ^ (x2 * y3) ^ (x3 * y2)) & MASK_1;
+    let z2 = ((x0 * y2) ^ (x1 * y1) ^ (x2 * y0) ^ (x3 * y3)) & MASK_2;
+    let z3 = ((x0 * y3) ^ (x1 * y2) ^ (x2 * y1) ^ (x3 * y0)) & MASK_3;
+    z0 | z1 | z2 | z3
 }
 
 /// A 256-bit integer.


### PR DESCRIPTION
This adds one more round of Karatsuba multiplication. We are now doing 64-bit multiplies in our leaf function instead of 128-bit multiplies. The compiler builtin `__multi3`, which implements 128-bit multiplication, uses four 64-bit multiplies, whereas using Karatsuba multiplication lets us halve the problem size with a recursive fanout of three instead. Our bit slicing can use fewer masks and multiplications as well, due to the smaller integer sizes. Overall, we go from 300 64-bit multiplies to 144 64-bit multiplies.

Based on the benchmark results in #169 and #171, this is faster than the bit reversal technique, even though it uses more multiplications (144 vs. 96).