### PR TITLE
Rewrite carryless multiplication fallback using bit reversal

### DIFF
--- a/src/fields/field2_128/backend_bit_slicing.rs
+++ b/src/fields/field2_128/backend_bit_slicing.rs
@@ -85,7 +85,8 @@ fn clmul64_lo(x: u64, y: u64) -> u64 {
     // except every fourth are masked off, so that the carries that accumulate during one integer
     // multiply won't interfere with the LSB of the next group of four bits in the integer product.
     // The topmost group may have up to 16 addends contributing to one output bit, but there is no
-    // next output bit for it to overflow into, and the rest all have 15 or fewer addends.
+    // next output bit for it to overflow into, and the rest all have 15 or fewer addends. See also
+    // https://www.bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/hash/ghash_ctmul64.c;h=a46f16fee977f6102abea7f7bcdf169a013c3e8e;hb=5f045c759957fdff8c85716e6af99e10901fdac0.
 
     let x0 = x & MASK_0;
     let x1 = x & MASK_1;


### PR DESCRIPTION
This changes our fallback implementation of carryless multiplication, following Matteo's suggestions here: https://github.com/abetterinternet/zk-cred-longfellow/pull/157#discussion_r2741504377. Instead of implementing a 64-bit x 64-bit -> 128-bit carryless multiplication with the bit slicing technique, we instead implement a 64-bit x 64-bit -> 64-bit carryless multiplication as our smallest primitive. Since widening multiplication gets implemented with the __multi3 builtin, and four 64-bit multiplications, this is good to get rid of, because there are multiple more efficient ways to decompose the problem. Next, we use this 64-bit x 64-bit -> 64-bit carryless multiplication twice in order to implement 64-bit x 64-bit -> 128-bit carryless multiplication, bit-reversing the inputs and output to get the top half.

If you draw out an addition table, assign the bits of one input to the rows, and assign the bits of the other input to the column, then you can represent each product of two bits with one table entry. The powers of the variable x in each monomial are determined by this addition table, i.e. the product of $a_i x^i$ and $b_j x^j$ is $a_i b_j x^{i+j}$. When we collect terms to get the carryless multiplication result, each bit of the output corresponds to the sum of all terms represented by a diagonal line of table entries, representing monomials with the same power of x. So, if our multiplication table is 64x64, then the top left triangular half of the table (including the diagonal) will give us the lowest 64 bits of the carryless multiplication product.

Bit reversing the inputs replaces $i \mapsto 63 - i$ and $j \mapsto 63 - i$. As a result, we will see $i + j \mapsto 126 - i - j$ as the powers of x in monomials of the output. This means the output when working on bit reversed inputs is itself bit reversed and shifted. Therefore, we can fill in the bottom right triangular half of the addition table, and thus the top half of the 128-bit carryless multiplication result, with this technique.

With this change, our implementation is pretty close to that of [BearSSL](https://www.bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/hash/ghash_ctmul64.c;h=a46f16fee977f6102abea7f7bcdf169a013c3e8e;hb=5f045c759957fdff8c85716e6af99e10901fdac0), save for the opposite bit endianness of GHASH/GCM. We may still be doing more work for the reduction step, but we can take a closer look at that separately.

As noted in the comments, we only need to use four masks, not five, for our 64-bit x 64-bit -> 64-bit carryless multiplication. Each mask has 64/4=16 bits set. We can only have sixteen products of masked input bits in the most significant mask position, where we do not need to worry about overflow. In other positions, we will have 15 or fewer bits added together, which is not enough to take up five bytes and overflow into the next output bit. Previously, we used five masks for 128-bit products, because the group that got the most products of bits was in the middle, and we couldn't allow overflow into the next bit of the output mask. This aspect of the change also saves us a good number of multiplications.