### PR TITLE
Changes to test circuit

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -857,16 +857,11 @@ pub(crate) mod tests {
                     },
                     // Assert x - 2 = 0. (occupying gate #2 on this layer)
                     // 0 = V[2][0] * V[2][2] + V[2][0] * V[2][3]
+                    // (This gate's quads are not contiguous when the circuit is properly sorted)
                     Quad {
                         gate_index: 2,
                         left_wire_index: 0,
                         right_wire_index: 2,
-                        const_table_index: 0,
-                    },
-                    Quad {
-                        gate_index: 2,
-                        left_wire_index: 0,
-                        right_wire_index: 3,
                         const_table_index: 0,
                     },
                     // Compute x^3 - 3x^2 + 2x.
@@ -876,6 +871,15 @@ pub(crate) mod tests {
                         left_wire_index: 1,
                         right_wire_index: 2,
                         const_table_index: 1,
+                    },
+                    // Assert x - 2 = 0. (occupying gate #2 on this layer)
+                    // 0 = V[2][0] * V[2][2] + V[2][0] * V[2][3]
+                    // (See above)
+                    Quad {
+                        gate_index: 2,
+                        left_wire_index: 0,
+                        right_wire_index: 3,
+                        const_table_index: 0,
                     },
                 ],
             },
@@ -893,23 +897,29 @@ pub(crate) mod tests {
                     },
                     // Calculate x^2 - 3x + 2.
                     // V[2][1] = 1 * V[3][1] * V[3][1] + -3 * V[3][0] * V[3][1] + 2 * V[3][0] * V[3][0]
-                    Quad {
-                        gate_index: 1,
-                        left_wire_index: 1,
-                        right_wire_index: 1,
-                        const_table_index: 1,
-                    },
-                    Quad {
-                        gate_index: 1,
-                        left_wire_index: 0,
-                        right_wire_index: 1,
-                        const_table_index: 4,
-                    },
+                    // (This gate's quads are not contiguous when the circuit is properly sorted)
                     Quad {
                         gate_index: 1,
                         left_wire_index: 0,
                         right_wire_index: 0,
                         const_table_index: 2,
+                    },
+                    // Calculate -2 (for assertion).
+                    // V[2][3] = -2 * V[3][0] * V[3][0]
+                    Quad {
+                        gate_index: 3,
+                        left_wire_index: 0,
+                        right_wire_index: 0,
+                        const_table_index: 3,
+                    },
+                    // Calculate x^2 - 3x + 2.
+                    // V[2][1] = 1 * V[3][1] * V[3][1] + -3 * V[3][0] * V[3][1] + 2 * V[3][0] * V[3][0]
+                    // (See above)
+                    Quad {
+                        gate_index: 1,
+                        left_wire_index: 0,
+                        right_wire_index: 1,
+                        const_table_index: 4,
                     },
                     // Propagate x to next layer (for assertion).
                     // V[2][2] = 1 * V[3][0] * V[3][1]
@@ -919,13 +929,14 @@ pub(crate) mod tests {
                         right_wire_index: 1,
                         const_table_index: 1,
                     },
-                    // Calculate -2 (for assertion).
-                    // V[2][3] = -2 * V[3][0] * V[3][0]
+                    // Calculate x^2 - 3x + 2.
+                    // V[2][1] = 1 * V[3][1] * V[3][1] + -3 * V[3][0] * V[3][1] + 2 * V[3][0] * V[3][0]
+                    // (See above)
                     Quad {
-                        gate_index: 3,
-                        left_wire_index: 0,
-                        right_wire_index: 0,
-                        const_table_index: 3,
+                        gate_index: 1,
+                        left_wire_index: 1,
+                        right_wire_index: 1,
+                        const_table_index: 1,
                     },
                 ],
             },

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -773,9 +773,10 @@ pub(crate) mod tests {
 
     /// This creates a simple circuit that exercises in-circuit assertions.
     ///
-    /// It takes one input, x, checks that x - 2 = 0 with an in-circuit assertion, and outputs
-    /// (x - 1) * (x - 2). Following convention, the input wire V[3][0] is set to the constant value
-    /// of 1, and V[3][1] is set to the input x. The circuit executes the following equations.
+    /// It takes one input, x, checks that x - 2 = 0 with an in-circuit assertion, and outputs two
+    /// values, (x - 1) * (x - 2) and x * (x - 1) * (x - 2). Following convention, the input wire
+    /// V[3][0] is set to the constant value of 1, and V[3][1] is set to the input x. The circuit
+    /// executes the following equations.
     ///
     /// ```text
     /// // Propagate 1 to next layer.
@@ -793,9 +794,13 @@ pub(crate) mod tests {
     /// V[1][1] = 1 * V[2][1] * V[2][0]
     /// // Assert x - 2 = 0. (occupying gate #2 on this layer)
     /// 0 = V[2][2] * V[2][0] + V[2][3] * V[2][0]
+    /// // Compute x^3 - 3x^2 + 2x.
+    /// V[1][3] = 1 * V[2][1] * V[2][2]
     ///
     /// // Propagate x^2 - 3x + 2 to output.
     /// V[0][0] = 1 * V[1][1] * V[1][0]
+    /// // Propagate x^3 - 3x^2 + 2x to output.
+    /// V[0][1] = 1 * V[1][3] * V[1][0]
     /// ```
     fn make_assertion_test_circuit() -> Circuit<FieldP128> {
         let constant_table = vec![
@@ -808,15 +813,25 @@ pub(crate) mod tests {
         let layers = vec![
             CircuitLayer {
                 logw: Size(2),
-                num_wires: Size(3),
-                quads: vec![Quad {
+                num_wires: Size(4),
+                quads: vec![
                     // Propagate x^2 - 3x + 2 to output.
                     // V[0][0] = 1 * V[1][1] * V[1][0]
-                    gate_index: 0,
-                    left_wire_index: 1,
-                    right_wire_index: 0,
-                    const_table_index: 1,
-                }],
+                    Quad {
+                        gate_index: 0,
+                        left_wire_index: 1,
+                        right_wire_index: 0,
+                        const_table_index: 1,
+                    },
+                    // Propagate x^3 - 3x^2 + 2x to output.
+                    // V[0][1] = 1 * V[1][3] * V[1][0]
+                    Quad {
+                        gate_index: 1,
+                        left_wire_index: 3,
+                        right_wire_index: 0,
+                        const_table_index: 1,
+                    },
+                ],
             },
             CircuitLayer {
                 logw: Size(2),
@@ -851,6 +866,14 @@ pub(crate) mod tests {
                         left_wire_index: 3,
                         right_wire_index: 0,
                         const_table_index: 0,
+                    },
+                    // Compute x^3 - 3x^2 + 2x.
+                    // V[1][3] = 1 * V[2][1] * V[2][2]
+                    Quad {
+                        gate_index: 3,
+                        left_wire_index: 1,
+                        right_wire_index: 2,
+                        const_table_index: 1,
                     },
                 ],
             },
@@ -907,11 +930,11 @@ pub(crate) mod tests {
         ];
         Circuit {
             version: 1,
-            num_outputs: 1,
+            num_outputs: 2,
             num_copies: 0,
             num_public_inputs: 1,
-            subfield_boundary: 1,
-            num_inputs: 1,
+            subfield_boundary: 2,
+            num_inputs: 2,
             num_layers: layers.len(),
             constant_table,
             layers,
@@ -946,6 +969,6 @@ pub(crate) mod tests {
         let evaluation = circuit
             .evaluate(&[FieldP128::ONE, FieldP128::from_u128(2)])
             .unwrap();
-        assert_eq!(evaluation.outputs()[0], FieldP128::ZERO);
+        assert_eq!(evaluation.outputs(), &[FieldP128::ZERO, FieldP128::ZERO]);
     }
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -782,25 +782,25 @@ pub(crate) mod tests {
     /// // Propagate 1 to next layer.
     /// V[2][0] = 1 * V[3][0] * V[3][0]
     /// // Calculate x^2 - 3x + 2.
-    /// V[2][1] = 1 * V[3][1] * V[3][1] + -3 * V[3][1] * V[3][0] + 2 * V[3][0] * V[3][0]
+    /// V[2][1] = 1 * V[3][1] * V[3][1] + -3 * V[3][0] * V[3][1] + 2 * V[3][0] * V[3][0]
     /// // Propagate x to next layer (for assertion).
-    /// V[2][2] = 1 * V[3][1] * V[3][0]
+    /// V[2][2] = 1 * V[3][0] * V[3][1]
     /// // Calculate -2 (for assertion).
     /// V[2][3] = -2 * V[3][0] * V[3][0]
     ///
     /// // Propagate 1 to next layer.
     /// V[1][0] = 1 * V[2][0] * V[2][0]
     /// // Propagate x^2 - 3x + 2 to next layer.
-    /// V[1][1] = 1 * V[2][1] * V[2][0]
+    /// V[1][1] = 1 * V[2][0] * V[2][1]
     /// // Assert x - 2 = 0. (occupying gate #2 on this layer)
-    /// 0 = V[2][2] * V[2][0] + V[2][3] * V[2][0]
+    /// 0 = V[2][0] * V[2][2] + V[2][0] * V[2][3]
     /// // Compute x^3 - 3x^2 + 2x.
     /// V[1][3] = 1 * V[2][1] * V[2][2]
     ///
     /// // Propagate x^2 - 3x + 2 to output.
-    /// V[0][0] = 1 * V[1][1] * V[1][0]
+    /// V[0][0] = 1 * V[1][0] * V[1][1]
     /// // Propagate x^3 - 3x^2 + 2x to output.
-    /// V[0][1] = 1 * V[1][3] * V[1][0]
+    /// V[0][1] = 1 * V[1][0] * V[1][3]
     /// ```
     ///
     /// This circuit only works over large-characteristic fields.
@@ -818,19 +818,19 @@ pub(crate) mod tests {
                 num_wires: Size(4),
                 quads: vec![
                     // Propagate x^2 - 3x + 2 to output.
-                    // V[0][0] = 1 * V[1][1] * V[1][0]
+                    // V[0][0] = 1 * V[1][0] * V[1][1]
                     Quad {
                         gate_index: 0,
-                        left_wire_index: 1,
-                        right_wire_index: 0,
+                        left_wire_index: 0,
+                        right_wire_index: 1,
                         const_table_index: 1,
                     },
                     // Propagate x^3 - 3x^2 + 2x to output.
-                    // V[0][1] = 1 * V[1][3] * V[1][0]
+                    // V[0][1] = 1 * V[1][0] * V[1][3]
                     Quad {
                         gate_index: 1,
-                        left_wire_index: 3,
-                        right_wire_index: 0,
+                        left_wire_index: 0,
+                        right_wire_index: 3,
                         const_table_index: 1,
                     },
                 ],
@@ -848,25 +848,25 @@ pub(crate) mod tests {
                         const_table_index: 1,
                     },
                     // Propagate x^2 - 3x + 2 to next layer.
-                    // V[1][1] = 1 * V[2][1] * V[2][0]
+                    // V[1][1] = 1 * V[2][0] * V[2][1]
                     Quad {
                         gate_index: 1,
-                        left_wire_index: 1,
-                        right_wire_index: 0,
+                        left_wire_index: 0,
+                        right_wire_index: 1,
                         const_table_index: 1,
                     },
                     // Assert x - 2 = 0. (occupying gate #2 on this layer)
-                    // 0 = V[2][2] * V[2][0] + V[2][3] * V[2][0]
+                    // 0 = V[2][0] * V[2][2] + V[2][0] * V[2][3]
                     Quad {
                         gate_index: 2,
-                        left_wire_index: 2,
-                        right_wire_index: 0,
+                        left_wire_index: 0,
+                        right_wire_index: 2,
                         const_table_index: 0,
                     },
                     Quad {
                         gate_index: 2,
-                        left_wire_index: 3,
-                        right_wire_index: 0,
+                        left_wire_index: 0,
+                        right_wire_index: 3,
                         const_table_index: 0,
                     },
                     // Compute x^3 - 3x^2 + 2x.
@@ -892,7 +892,7 @@ pub(crate) mod tests {
                         const_table_index: 1,
                     },
                     // Calculate x^2 - 3x + 2.
-                    // V[2][1] = 1 * V[3][1] * V[3][1] + -3 * V[3][1] * V[3][0] + 2 * V[3][0] * V[3][0]
+                    // V[2][1] = 1 * V[3][1] * V[3][1] + -3 * V[3][0] * V[3][1] + 2 * V[3][0] * V[3][0]
                     Quad {
                         gate_index: 1,
                         left_wire_index: 1,
@@ -901,8 +901,8 @@ pub(crate) mod tests {
                     },
                     Quad {
                         gate_index: 1,
-                        left_wire_index: 1,
-                        right_wire_index: 0,
+                        left_wire_index: 0,
+                        right_wire_index: 1,
                         const_table_index: 4,
                     },
                     Quad {
@@ -912,11 +912,11 @@ pub(crate) mod tests {
                         const_table_index: 2,
                     },
                     // Propagate x to next layer (for assertion).
-                    // V[2][2] = 1 * V[3][1] * V[3][0]
+                    // V[2][2] = 1 * V[3][0] * V[3][1]
                     Quad {
                         gate_index: 2,
-                        left_wire_index: 1,
-                        right_wire_index: 0,
+                        left_wire_index: 0,
+                        right_wire_index: 1,
                         const_table_index: 1,
                     },
                     // Calculate -2 (for assertion).

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -802,13 +802,15 @@ pub(crate) mod tests {
     /// // Propagate x^3 - 3x^2 + 2x to output.
     /// V[0][1] = 1 * V[1][3] * V[1][0]
     /// ```
-    fn make_assertion_test_circuit() -> Circuit<FieldP128> {
+    ///
+    /// This circuit only works over large-characteristic fields.
+    pub(crate) fn make_assertion_test_circuit<FE: FieldElement>() -> Circuit<FE> {
         let constant_table = vec![
-            FieldP128::ZERO,
-            FieldP128::ONE,
-            FieldP128::from(2),
-            -FieldP128::from(2), // constant table index 3
-            -FieldP128::from(3), // constant table index 4
+            FE::ZERO,
+            FE::ONE,
+            FE::from(2),
+            -FE::from(2), // constant table index 3
+            -FE::from(3), // constant table index 4
         ];
         let layers = vec![
             CircuitLayer {


### PR DESCRIPTION
This makes some changes to the small test circuit we construct by hand. I have been using this updated circuit when working through interoperability bugs in the Sage implementation. This includes the following changes:

* Add another circuit output, for a total of two. This would catch some implementation bugs we ran into previously when the log of the number of circuit outputs is nonzero.
* Canonicalize the quad terms, so that the left wire index is always less than the right wire index. This matches what the circuit compiler does. I don't think this is necessary, but this makes for one fewer potential surprise.
* Sort the quads into the sumcheck-sympathetic ordering. This is required in order for us to produce proofs over this circuit.
* Fix the `num_inputs` parameter.