### PR TITLE
Drop constant-only terms from symbolic expressions

### DIFF
--- a/src/sumcheck/constraints/mod.rs
+++ b/src/sumcheck/constraints/mod.rs
@@ -139,7 +139,9 @@ impl<FE: FieldElement> SymbolicExpression<FE> {
 impl<FE: FieldElement> AddAssign<Term<FE>> for SymbolicExpression<FE> {
     fn add_assign(&mut self, rhs: Term<FE>) {
         self.known += rhs.known;
-        self.terms.push(rhs.symbolic);
+        if rhs.symbolic.witness_index.is_some() {
+            self.terms.push(rhs.symbolic);
+        }
     }
 }
 


### PR DESCRIPTION
I noticed that when we build up a `SymbolicExpression` through addition, we are currently keeping multiple `Symbolic`s with no witness variable index. These come from `Term`s with only a constant. The constant gets folded into the `known` field, while the `Symbolic` part, with no variable, has no impact on the expression. This gets us the following speedup. (measured with Turbo Boost turned off)

```
Benchmarking prove: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 180.0s. You may wish to increase target time to 387.0s, or reduce sample count to 40.
prove                   time:   [3.7704 s 3.7723 s 3.7744 s]
                        change: [−1.7169% −1.6336% −1.5474%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe

Benchmarking verify: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 180.0s. You may wish to increase target time to 191.8s, or reduce sample count to 90.
verify                  time:   [1.9173 s 1.9198 s 1.9236 s]
                        change: [−1.5681% −1.3409% −1.1057%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  3 (3.00%) high mild
  4 (4.00%) high severe
```

We could probably clean this up further by changing the types so that a `SymbolicExpression` doesn't contain any `Option`s inside its list of linear symbolic terms, but this is a quick easy win.