### PR TITLE
Check if input lengths are correct

### DIFF
--- a/src/mdoc_zk/prover.rs
+++ b/src/mdoc_zk/prover.rs
@@ -122,6 +122,14 @@ impl MdocZkProver {
             &mac_prover_key_shares,
         )?;
 
+        // Check input sizes against circuit metadata.
+        if inputs.hash_input().len() != self.hash_circuit.num_inputs() {
+            return Err(anyhow!("input length does not match hash circuit"));
+        }
+        if inputs.signature_input().len() != self.signature_circuit.num_inputs() {
+            return Err(anyhow!("input length does not match signature circuit"));
+        }
+
         // Initialize Fiat-Shamir transcript.
         let mut transcript = Transcript::new(session_transcript, TranscriptMode::Normal)?;
 
@@ -267,5 +275,43 @@ mod tests {
                 &test_vector_inputs.now,
             )
             .unwrap();
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_generate_proof_wrong_circuit_a() {
+        let compressed = include_bytes!("../../test-vectors/mdoc_zk/6_1_137e5a75ce72735a37c8a72da1a8a0a5df8d13365c2ae3d2c2bd6a0e7197c7c6").as_slice();
+        let decompressed = zstd::decode_all(compressed).unwrap();
+        let prover = MdocZkProver::new(&decompressed, CircuitVersion::V7, 1).unwrap();
+
+        let test_vector_inputs = load_v6_v7_test_vector_inputs();
+
+        prover
+            .prove(
+                &test_vector_inputs.mdoc,
+                "org.iso.18013.5.1",
+                &[&test_vector_inputs.attributes[0].id],
+                &test_vector_inputs.transcript,
+                &test_vector_inputs.now,
+            )
+            .unwrap_err();
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_generate_proof_wrong_circuit_b() {
+        let compressed = include_bytes!("../../test-vectors/mdoc_zk/7_1_8d079211715200ff06c5109639245502bfe94aa869908d31176aae4016182121").as_slice();
+        let decompressed = zstd::decode_all(compressed).unwrap();
+        let prover = MdocZkProver::new(&decompressed, CircuitVersion::V6, 1).unwrap();
+
+        let test_vector_inputs = load_v6_v7_test_vector_inputs();
+
+        prover
+            .prove(
+                &test_vector_inputs.mdoc,
+                "org.iso.18013.5.1",
+                &[&test_vector_inputs.attributes[0].id],
+                &test_vector_inputs.transcript,
+                &test_vector_inputs.now,
+            )
+            .unwrap_err();
     }
 }

--- a/src/mdoc_zk/verifier.rs
+++ b/src/mdoc_zk/verifier.rs
@@ -109,6 +109,14 @@ impl MdocZkVerifier {
             mac_verifier_key_share,
         )?;
 
+        // Check public input sizes against circuit metadata.
+        if statements.hash_statement().len() != self.hash_circuit.num_public_inputs() {
+            return Err(anyhow!("statement length does not match hash circuit"));
+        }
+        if statements.signature_statement().len() != self.signature_circuit.num_public_inputs() {
+            return Err(anyhow!("statement length does not match signature circuit"));
+        }
+
         // Run Sumcheck and Ligero on hash circuit.
         initialize_transcript(
             &mut transcript,

--- a/src/zk_one_circuit/prover.rs
+++ b/src/zk_one_circuit/prover.rs
@@ -39,8 +39,13 @@ impl<'a, FE: ProofFieldElement> Prover<'a, FE> {
     /// proven. This includes both the statement, or public inputs, and the witness, or private
     /// inputs. The definition of the circuit determines which inputs are which.
     pub fn prove(&self, session_id: &[u8], inputs: &[FE]) -> Result<Proof<FE>, anyhow::Error> {
-        // Evaluate circuit.
         let circuit = self.sumcheck_prover.circuit();
+
+        if inputs.len() != circuit.num_inputs() {
+            return Err(anyhow!("input length does not match circuit"));
+        }
+
+        // Evaluate circuit.
         let evaluation = circuit.evaluate(inputs)?;
 
         // Select one-time-pad, and combine with circuit witness into the Ligero witness.

--- a/src/zk_one_circuit/verifier.rs
+++ b/src/zk_one_circuit/verifier.rs
@@ -6,6 +6,7 @@ use crate::{
     transcript::{Transcript, TranscriptMode},
     zk_one_circuit::prover::Proof,
 };
+use anyhow::anyhow;
 
 /// Longfellow ZK verifier.
 pub struct Verifier<'a, FE: ProofFieldElement> {
@@ -33,6 +34,10 @@ impl<'a, FE: ProofFieldElement> Verifier<'a, FE> {
     where
         FE: ProofFieldElement,
     {
+        if statement.len() != self.circuit.num_public_inputs() {
+            return Err(anyhow!("statement length does not match circuit"));
+        }
+
         // Start of Fiat-Shamir transcript.
         let mut transcript =
             Transcript::new(proof.oracle(), TranscriptMode::V3Compatibility).unwrap();


### PR DESCRIPTION
This adds checks that input lengths match the corresponding circuit metadata. When using the wrong circuit, depending on the values, it was previously possible to hit a panic from an out-of-bounds access into the witness slice when building the tableau.