### PR TITLE
Add context to errors

### DIFF
--- a/src/mdoc_zk/mdoc/mod.rs
+++ b/src/mdoc_zk/mdoc/mod.rs
@@ -457,6 +457,7 @@ pub(super) fn compute_credential_hash<'a, 'b: 'a>(
         .context("could not encode Sig_structure")?;
 
     run_sha256_witnessed(message.as_slice(), witness, bit_plucker, max_blocks)
+        .context("error hashing credential")
 }
 
 /// Convert a SHA-256 hash from an ECDSA signature into a base field element for use as a circuit input.

--- a/src/mdoc_zk/mod.rs
+++ b/src/mdoc_zk/mod.rs
@@ -144,13 +144,15 @@ impl CircuitInputs {
             AffinePoint::new(mdoc.issuer_public_key_x, mdoc.issuer_public_key_y),
             mdoc.issuer_signature,
             credential_hash,
-        )?;
+        )
+        .context("problem building issuer signature witness")?;
         fill_ecdsa_witness(
             &mut split_signature_input.device_ecdsa_witness,
             mdoc.device_public_key,
             mdoc.device_signature,
             session_transcript_hash,
-        )?;
+        )
+        .context("problem building device signature witness")?;
 
         // Serialize MAC prover key shares to bytes.
         let mut mac_prover_key_shares_buffer =


### PR DESCRIPTION
This adds some `anyhow` context in some more places to help differentiate between issues related to the device signature or issuer signature.