### PR TITLE
Remove two branches on intermediate computations

### DIFF
--- a/src/sumcheck/bind/mod.rs
+++ b/src/sumcheck/bind/mod.rs
@@ -255,11 +255,7 @@ pub(crate) mod tests {
                         saw_element = true;
                     }
                 }
-                if *element == FE::ZERO {
-                    assert!(!saw_element)
-                } else {
-                    assert!(saw_element);
-                }
+                assert!(saw_element);
             }
         }
     }

--- a/src/sumcheck/bind/sparse.rs
+++ b/src/sumcheck/bind/sparse.rs
@@ -192,6 +192,11 @@ pub struct SparseQuadElement<FE> {
 
 impl<'a, FE: FieldElement> SparseQuadElement<FE> {
     /// A new sparse quad element, assigning the wire indices based on the indicated handedness.
+    ///
+    /// Note that the coefficient is allowed to be zero, to account for rare cases where
+    /// calculations cancel out. For efficiency, circuit files should not include quad elements with
+    /// a coefficient of zero. For side channel resistance, we should not treat zeros that arise
+    /// during proof generation differently than other values.
     fn new(
         gate_index: usize,
         hand: Hand,

--- a/src/sumcheck/bind/sparse.rs
+++ b/src/sumcheck/bind/sparse.rs
@@ -199,11 +199,6 @@ impl<'a, FE: FieldElement> SparseQuadElement<FE> {
         opposite_hand_wire: usize,
         coefficient: FE,
     ) -> Self {
-        debug_assert_ne!(
-            coefficient,
-            FE::ZERO,
-            "sparse array should not contain elements with zero coefficient",
-        );
         let (left_wire_index, right_wire_index) = match hand {
             Hand::Left => (hand_wire, opposite_hand_wire),
             Hand::Right => (opposite_hand_wire, hand_wire),
@@ -437,18 +432,15 @@ impl<FE: FieldElement> SparseSumcheckArray<FE> {
                 binding * curr.coefficient
             };
 
-            // Don't bother writing elements with zero coefficient
-            if coefficient != FE::ZERO {
-                self.contents[write] = SparseQuadElement::new(
-                    0,
-                    hand,
-                    // 2i-th or 2i+1-th element contributes to the i-th bound element
-                    curr.hand_wire(hand) >> 1,
-                    curr.hand_wire(hand.opposite()),
-                    coefficient,
-                );
-                write += 1;
-            }
+            self.contents[write] = SparseQuadElement::new(
+                0,
+                hand,
+                // 2i-th or 2i+1-th element contributes to the i-th bound element
+                curr.hand_wire(hand) >> 1,
+                curr.hand_wire(hand.opposite()),
+                coefficient,
+            );
+            write += 1;
         }
 
         // Truncate the sparse array, which effectively zeroes out all elements of the original

--- a/src/sumcheck/mod.rs
+++ b/src/sumcheck/mod.rs
@@ -422,14 +422,13 @@ impl<'a, FE: ProofFieldElement> SumcheckProtocol<'a, FE> {
                             quad.compute_a(hand, wires, wires_scratch);
 
                             let evaluate_polynomial = |at| {
-                                wires_scratch
-                                    .bind_iter(at)
-                                    .enumerate()
-                                    .filter(|(_, fe)| bool::from(!fe.is_zero()))
-                                    .fold(FE::ZERO, |acc, (index, element)| {
+                                wires_scratch.bind_iter(at).enumerate().fold(
+                                    FE::ZERO,
+                                    |acc, (index, element)| {
                                         acc + element
                                             * wires[hand as usize].bound_element_at(at, index)
-                                    })
+                                    },
+                                )
                             };
 
                             // Evaluate the polynomial at P0 and P2, subtracting the pad


### PR DESCRIPTION
This removes a couple branches that check if field elements are equal to zero, when binding a sparse array and when computing evaluations of the sumcheck polynomial. This both reduces potential side channels and marginally improves verifier performance, which is a nice plus. (measurements taken with Turbo Boost disabled)

```
Git revision: 18b0647-modified

Benchmarking prove: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 180.0s. You may wish to increase target time to 389.3s, or reduce sample count to 40.
prove                   time:   [3.8328 s 3.8354 s 3.8376 s]
                        change: [−0.7921% −0.7111% −0.6326%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) low severe
  6 (6.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe

Benchmarking verify: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 180.0s. You may wish to increase target time to 191.2s, or reduce sample count to 90.
verify                  time:   [1.9187 s 1.9202 s 1.9222 s]
                        change: [−2.8581% −2.7810% −2.6815%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe
```