### PR TITLE
Add inline attribute to run_protocol()

### DIFF
--- a/src/sumcheck/mod.rs
+++ b/src/sumcheck/mod.rs
@@ -250,6 +250,7 @@ impl<'a, FE: ProofFieldElement> SumcheckProtocol<'a, FE> {
     /// [6.6][2]. Both are run when in `ProtocolRole::Prover`, and only constraints are computed
     /// when in `ProtocolRole::Verifier`. Besides some code reuse, doing both computations at once
     /// speeds up the prover considerably.
+    #[inline(always)] // Make sure branching on ProtocolRole discriminant gets optimized away
     fn run_protocol(
         &self,
         transcript: &mut Transcript,


### PR DESCRIPTION
This adds an inline attribute to the `run_protocol()`, so that the compiler can propagate the discriminant of `ProtocolRole`, eliminating some branches inside loops and dead code. This has a positive impact on benchmarks, again taken with Turbo Boost disabled.

```
Git revision: 18b0647-modified

Benchmarking prove: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 180.0s. You may wish to increase target time to 387.0s, or reduce sample count to 40.
prove                   time:   [3.7771 s 3.7791 s 3.7813 s]
                        change: [−1.2037% −1.1331% −1.0594%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

Benchmarking verify: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 180.0s. You may wish to increase target time to 192.2s, or reduce sample count to 90.
verify                  time:   [1.9149 s 1.9155 s 1.9161 s]
                        change: [−2.2712% −2.0506% −1.9153%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
```