### PR TITLE
Use as_chunks instead of chunks_exact with constant sizes

### DIFF
--- a/src/mdoc_zk/bit_plucker.rs
+++ b/src/mdoc_zk/bit_plucker.rs
@@ -27,7 +27,7 @@ impl BitPlucker<4, Field2_128> {
     pub(super) fn encode_u32_array(&self, words: &[u32], out: &mut [Field2_128]) {
         assert_eq!(words.len() * 32, out.len() * 4);
         let mask = u16::MAX >> (u16::BITS - 4);
-        for (word, out_chunk) in words.iter().zip(out.chunks_exact_mut(32 / 4)) {
+        for (word, out_chunk) in words.iter().zip(out.as_chunks_mut::<{ 32 / 4 }>().0) {
             let mut bits = *word;
             for out_elem in out_chunk.iter_mut() {
                 *out_elem = self.encode(bits as u16 & mask);

--- a/src/mdoc_zk/layout.rs
+++ b/src/mdoc_zk/layout.rs
@@ -572,7 +572,9 @@ pub(super) struct Sha256Witness<'a> {
 impl<'a> Sha256Witness<'a> {
     pub(super) fn iter_blocks(&'a mut self) -> impl Iterator<Item = Sha256BlockWitness<'a>> {
         self.input
-            .chunks_exact_mut(Sha256BlockWitness::LENGTH)
+            .as_chunks_mut::<{ Sha256BlockWitness::LENGTH }>()
+            .0
+            .iter_mut()
             .map(|input| {
                 let (message_schedule, input) = input.split_at_mut(48 * 32 / 4);
                 let (state_e_a, input) = input.split_at_mut(64 * 2 * 32 / 4);

--- a/src/mdoc_zk/mod.rs
+++ b/src/mdoc_zk/mod.rs
@@ -165,9 +165,11 @@ impl CircuitInputs {
         // Set signature circuit MAC witnesses, interleaving key shares and messages.
         let sig_mac_bit_plucker = BitPlucker::<2, FieldP256>::new();
         for ((key_shares_chunk, message), out) in mac_prover_key_shares_buffer
-            .chunks_exact(32)
-            .zip(mac_messages_buffer.chunks_exact(32))
-            .zip(split_signature_input.mac_witnesses.chunks_exact_mut(256))
+            .as_chunks::<32>()
+            .0
+            .iter()
+            .zip(mac_messages_buffer.as_chunks::<32>().0)
+            .zip(split_signature_input.mac_witnesses.as_chunks_mut::<256>().0)
         {
             sig_mac_bit_plucker.encode_byte_array(key_shares_chunk, &mut out[..128]);
             sig_mac_bit_plucker.encode_byte_array(message, &mut out[128..]);
@@ -544,7 +546,7 @@ impl CircuitInputs {
         let sig = self.layout.split_signature_input(&mut self.signature_input);
         for (tag, wires) in tags
             .iter()
-            .zip(sig.statement.mac_tags.chunks_exact_mut(128))
+            .zip(sig.statement.mac_tags.as_chunks_mut::<128>().0)
         {
             for (bit, wire) in tag.iter_bits().zip(wires.iter_mut()) {
                 *wire = FieldP256::from_u128(bit as u128);
@@ -609,7 +611,7 @@ fn fill_attribute_statement_v7(
 
 /// Encode an array of bytes as field elements, with one field element representing each bit.
 fn byte_array_as_bits(bytes: &[u8], out: &mut [Field2_128]) {
-    for (byte, out_chunk) in bytes.iter().zip(out.chunks_exact_mut(8)) {
+    for (byte, out_chunk) in bytes.iter().zip(out.as_chunks_mut::<8>().0) {
         let mut bits = *byte;
         for out_elem in out_chunk.iter_mut() {
             *out_elem = Field2_128::inject_bits::<1>((bits & 1) as u16);
@@ -754,7 +756,7 @@ impl CircuitStatements {
         for (tag, wires) in proof
             .mac_tags
             .iter()
-            .zip(split_signature_statement.mac_tags.chunks_exact_mut(128))
+            .zip(split_signature_statement.mac_tags.as_chunks_mut::<128>().0)
         {
             for (bit, wire) in tag.iter_bits().zip(wires.iter_mut()) {
                 *wire = FieldP256::from_u128(bit as u128);

--- a/src/mdoc_zk/sha256.rs
+++ b/src/mdoc_zk/sha256.rs
@@ -53,9 +53,8 @@ pub(super) fn run_sha256(input: &[u8]) -> Sha256Digest {
     let mut padded_input = input.to_vec();
     pad_input(&mut padded_input);
     let mut hash_value = INITIAL_HASH_VALUE;
-    for chunk in padded_input.chunks_exact(64) {
-        // Unwrap safety: chunks_exact above guarantees the length is correct.
-        process_block(chunk.try_into().unwrap(), &mut hash_value);
+    for chunk in padded_input.as_chunks::<64>().0 {
+        process_block(chunk, &mut hash_value);
     }
     serialize_hash_value(&hash_value)
 }
@@ -79,17 +78,13 @@ pub(super) fn run_sha256_witnessed<'a, 'b: 'a>(
     let mut hash_value = INITIAL_HASH_VALUE;
     let mut digest = None;
     for (block_number, (chunk, mut block_witness)) in padded_input
-        .chunks_exact(64)
+        .as_chunks::<64>()
+        .0
+        .iter()
         .zip(witness.iter_blocks())
         .enumerate()
     {
-        // Unwrap safety: chunks_exact above guarantees the length is correct.
-        witness_block(
-            chunk.try_into().unwrap(),
-            &mut hash_value,
-            &mut block_witness,
-            bit_plucker,
-        );
+        witness_block(chunk, &mut hash_value, &mut block_witness, bit_plucker);
         if block_number + 1 == num_blocks {
             digest = Some(serialize_hash_value(&hash_value));
         }
@@ -135,7 +130,7 @@ pub(super) fn witness_block(
     for ((k_t, w_t), state_e_a) in K
         .iter()
         .zip(&message_schedule)
-        .zip(witness.state_e_a.chunks_exact_mut(2 * 32 / 4))
+        .zip(witness.state_e_a.as_chunks_mut::<{ 2 * 32 / 4 }>().0)
     {
         round(&mut state, *k_t, *w_t);
         bit_plucker.encode_u32_array(&[state[4], state[0]], state_e_a);
@@ -157,9 +152,8 @@ fn message_schedule(message: &[u8; 64]) -> [u32; 64] {
     let mut schedule = [0u32; 64];
 
     // Parse the message.
-    for (mi, chunk) in schedule[..16].iter_mut().zip(message.chunks_exact(4)) {
-        // Unwrap safety: chunks_exact above guarantees the length is correct.
-        *mi = u32::from_be_bytes(chunk.try_into().unwrap());
+    for (mi, chunk) in schedule[..16].iter_mut().zip(message.as_chunks::<4>().0) {
+        *mi = u32::from_be_bytes(*chunk);
     }
 
     // Compute the rest of the message schedule from its recurrence relation.
@@ -194,8 +188,8 @@ fn round(state: &mut [u32; 8], k_t: u32, w_t: u32) {
 
 fn serialize_hash_value(hash_value: &[u32; 8]) -> Sha256Digest {
     let mut output = Sha256Digest([0; 32]);
-    for (h, chunk) in hash_value.iter().zip(output.0.chunks_exact_mut(4)) {
-        chunk.copy_from_slice(&h.to_be_bytes());
+    for (h, chunk) in hash_value.iter().zip(output.0.as_chunks_mut::<4>().0) {
+        *chunk = h.to_be_bytes();
     }
     output
 }


### PR DESCRIPTION
## Why

Rust 1.98.0 made `clippy::chunks_exact_to_as_chunks` warn-by-default. It fires 13 times in `mdoc_zk`, so `cargo clippy --workspace --all-targets -- -Dwarnings` — the command `ci.yml` runs — now fails on `main`.

This is latent rather than visible: CI last ran here on 2026-08-07, before that release. The next run on `main` will hit it, as will any new PR.

## It's not only a lint

Applying it removes three fallible conversions from the SHA-256 code, because `as_chunks::<N>()` yields `&[T; N]` rather than `&[T]`:

```rust
// before
// Unwrap safety: chunks_exact above guarantees the length is correct.
process_block(chunk.try_into().unwrap(), &mut hash_value);

// after
process_block(chunk, &mut hash_value);
```

The 64-byte block length is now carried by the type instead of asserted in a comment and enforced by a runtime `unwrap`. Same for `u32::from_be_bytes(chunk.try_into().unwrap())` → `u32::from_be_bytes(*chunk)` in `message_schedule`, and a `copy_from_slice` that becomes a plain assignment in `serialize_hash_value`.

## Why `cargo clippy --fix` can't do this

Clippy's suggestion doesn't compile — it emits `as_chunks::<Sha256BlockWitness::LENGTH>()`, which is `E0747`. The const-generic argument needs bracing, as do the computed sizes (`{ 32 / 4 }`, `{ 2 * 32 / 4 }`). Hence applied by hand.

Everything else is mechanical: `chunks_exact(N)` → `as_chunks::<N>().0`, `chunks_exact_mut(N)` → `as_chunks_mut::<N>().0`, plus `.iter()`/`.iter_mut()` where an `Iterator` rather than a slice was needed. Both forms discard a trailing partial chunk, so behaviour is unchanged.

## Verified

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -Dwarnings` clean
- `cargo test --release` — 176 passed, 0 failed

The SHA-256 tests check `run_sha256` against the independent `sha2` crate exhaustively over lengths 0..=65, spanning the 64-byte block boundary this rewrite touches — so an off-by-one or mishandled remainder would fail there.

---

Found while working on a downstream fork. Happy to adjust the style if you'd prefer the `#[allow]` route instead — but the `try_into().unwrap()` removals seemed worth having on their own.