### PR TITLE
Pin the Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Rust toolchain
+      # Version, components and targets all come from rust-toolchain.toml,
+      # which rustup honours for every cargo invocation here.
       uses: dtolnay/rust-toolchain@stable
-      with:
-        components: clippy, rustfmt
     - uses: actions/checkout@v5
     - name: Build
       run: cargo build
@@ -44,8 +44,6 @@ jobs:
     steps:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: wasm32-unknown-unknown
     - name: Install Node.js
       uses: actions/setup-node@v5
       with:
@@ -63,8 +61,6 @@ jobs:
     steps:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: wasm32-unknown-unknown
     - name: Install cargo-binstall
       uses: cargo-bins/cargo-binstall@v1.15.7
     - name: Install wasm-pack

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,18 @@
+# Pin the toolchain so a Rust release can't change CI's result on its own.
+#
+# ci.yml used dtolnay/rust-toolchain@stable, which makes every Rust release
+# an unannounced CI change. Concretely: 1.98.0 made
+# clippy::chunks_exact_to_as_chunks warn-by-default, which fails the
+# `-Dwarnings` clippy job with no commit behind it.
+#
+# rustup honours this file for every cargo invocation in the repo, so local
+# builds and CI agree by construction. Bump it deliberately, in its own
+# commit, so a new lint or codegen change is attributable to that bump
+# rather than to whatever else merged that day.
+[toolchain]
+channel = "1.98.0"
+components = ["clippy", "rustfmt"]
+# Declared here rather than per-job in ci.yml: the workflow's `targets:`
+# input installs them for whichever toolchain the action selected, which is
+# not necessarily the one cargo ends up using.
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Why

`ci.yml` uses `dtolnay/rust-toolchain@stable`, which makes every Rust release an unannounced CI change.

Concretely: 1.98.0 made `clippy::chunks_exact_to_as_chunks` warn-by-default, which fails the `-Dwarnings` clippy job with no commit behind it. CI last ran on `main` on 2026-08-07, before that release — so the breakage is latent, and lands on whoever opens the next PR rather than on the change that caused it. That's a bad place for it to surface.

## What

`rust-toolchain.toml` pins 1.98.0 (current stable) and declares the components and targets `ci.yml` needs. rustup honours it for every cargo invocation in the repo, so local builds and CI agree by construction rather than by coincidence. Bump it deliberately, in its own commit, so a new lint or codegen change is attributable to that bump rather than to whatever else merged that day.

Also drops the per-job `components:`/`targets:` inputs: those install for whichever toolchain the *action* selected, which is no longer necessarily the one cargo uses. Declaring them in `rust-toolchain.toml` is what guarantees they're present for the pinned toolchain — verified `wasm32-unknown-unknown` is installed for 1.98.0 from the file alone.

## Verified

- rustup honours the file — `rustc --version` reports 1.98.0 in the repo without any other action
- `wasm32-unknown-unknown` installed for the pinned toolchain, so removing the workflow inputs can't break the wasm jobs
- **This does not mask the clippy failure**: with 1.98.0 pinned and no other change, clippy still reports the same errors

## Ordering

Please merge #231 first — it fixes the lint itself. This PR alone leaves CI red (correctly so: pinning shouldn't hide a real failure). Together they make CI deterministic and green.

---

Found while working on a downstream fork. Version choice is entirely yours — happy to pin to whatever you'd prefer, or to drop the `ci.yml` cleanup if you'd rather keep the inputs.